### PR TITLE
feat: formalize scene schema v1 and strengthen validation/regression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,13 @@ src/
 │   ├── animation.rs     # LinearAnimation, KeyFrame types
 │   └── state_machine.rs # StateMachine, Layer, States, Transitions, Conditions
 ├── builder/
-│   └── scene.rs         # JSON → Vec<Box<dyn RiveObject>> via SceneSpec
+│   └── scene.rs         # JSON → Result<Vec<Box<dyn RiveObject>>, String> via SceneSpec
 └── validator/
     └── mod.rs           # BinaryReader, parse_riv, validate_riv, inspect_riv
 tests/
 ├── e2e.rs               # Integration tests (cargo run subprocess)
-└── fixtures/            # JSON fixtures (minimal, shapes, animation, state_machine)
+├── fixtures/            # JSON fixtures (minimal, shapes, animation, state_machine, path)
+└── playwright/          # Runtime load harness + regression script
 ```
 
 ## CURRENT WORKTREE SNAPSHOT
@@ -107,7 +108,7 @@ cli/mod.rs
 
 ```bash
 cargo build
-cargo test                                    # 126 tests (117 unit + 9 e2e)
+cargo test                                    # 131 tests (121 unit + 10 e2e)
 cargo run -- generate input.json -o out.riv   # JSON → .riv
 cargo run -- validate out.riv                 # structural check
 cargo run -- inspect out.riv                  # dump object tree
@@ -118,10 +119,10 @@ cargo fmt --check                             # format check
 
 ## TEST INFRASTRUCTURE
 
-- `cargo test` currently runs **126 tests total**: **117 unit tests** + **9 e2e tests**
+- `cargo test` currently runs **131 tests total**: **121 unit tests** + **10 e2e tests**
 - E2E coverage lives in `tests/e2e.rs` and executes CLI subprocesses for `generate`, `validate`, and `inspect`
-- Fixtures for e2e live in `tests/fixtures/` (`minimal.json`, `shapes.json`, `animation.json`, `state_machine.json`)
-- Visual/manual runtime verification harness is available at `/tmp/rive-visual-test/` (Playwright-driven browser checks and screenshots)
+- Fixtures for e2e live in `tests/fixtures/` (`minimal.json`, `shapes.json`, `animation.json`, `state_machine.json`, `path.json`)
+- Playwright runtime regression checks live in `tests/playwright/` and run via `npx -y -p playwright node tests/playwright/regression.js`
 
 ## BINARY FORMAT QUICK REF
 
@@ -138,6 +139,7 @@ cargo fmt --check                             # format check
 - `.claudeignore` excludes `README.md` from context
 - C++ runtime source cloned to `/tmp/rive-runtime/` for reference
 - Visual test harness at `/tmp/rive-visual-test/` with Playwright automation
+- Scene input is versioned with `scene_format_version` (current value `1`) and JSON schema lives at `docs/scene.schema.v1.json`
 - **Active bug**: StateMachineLayer (type 57) causes WASM runtime "may be corrupt" error — under investigation
 - No CI/CD pipeline yet — no `.github/workflows/`
 - `thiserror` v2 is a dependency but not yet used (validator uses `String` errors)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,36 @@ rive-cli inspect existing.riv
 echo '{"artboard": {"width": 500, "height": 500, "children": [...]}}' | rive-cli generate -o output.riv
 ```
 
+Scene specs are versioned with `scene_format_version` and currently require `1`.
+
+```json
+{
+  "scene_format_version": 1,
+  "artboard": {
+    "name": "Main",
+    "width": 500,
+    "height": 500,
+    "children": []
+  }
+}
+```
+
+## Testing
+
+```bash
+cargo test
+
+# Runtime compatibility regression checks via official Rive web runtime
+npx -y -p playwright node tests/playwright/regression.js
+```
+
+The Playwright suite generates fixture `.riv` files, serves a local harness that loads `@rive-app/canvas`, and fails on runtime load or browser errors.
+
+## Internal Format Notes
+
+- `docs/format-spec.md` tracks encoding behaviors and compatibility constraints discovered during implementation.
+- `docs/scene.schema.v1.json` defines the versioned JSON schema for editor validation and autocompletion.
+
 ## Reference Material
 
 - [.riv format specification](https://rive.app/docs/runtimes/advanced-topic/format)

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -1,0 +1,49 @@
+# Rive Encoding Notes
+
+This document tracks format behavior validated during `rive-cli` development and bug fixing.
+
+## Header
+
+- Fingerprint: ASCII `RIVE` (4 bytes)
+- Version: major varuint (`7`), minor varuint (`0`)
+- File id: varuint
+- Followed by ToC bytes
+
+## Table of Contents (ToC)
+
+- Property keys are written as varuint sequence, terminated by `0`
+- Backing types are packed in 2-bit fields in little-endian `u32` words
+- One `u32` holds 16 properties (`16 * 2 = 32 bits`)
+- Backing bits:
+  - `0` = uint/bool
+  - `1` = string
+  - `2` = float
+  - `3` = color
+
+## Objects
+
+- Each object starts with object `type_key` varuint
+- Then repeated `property_key` + property value entries
+- Object terminator is property key `0`
+
+## Backing Type Rules
+
+- Bool properties are encoded as single byte, not LEB128 varuint
+- Float properties are encoded as `f32` little-endian
+- Color values are encoded as `u32` little-endian
+
+## Emission Rules Required for Runtime Compatibility
+
+- Do not include baseline properties in ToC: name (`4`), parentId (`5`), width (`7`), height (`8`)
+- Artboard property order must be width (`7`) -> height (`8`) -> name (`4`)
+- Artboard must not emit parentId
+- LinearAnimation emits defaults selectively:
+  - always: name/fps/duration
+  - optional when non-default: speed/loop/workStart/workEnd
+  - never emit quantize (`376`)
+
+## State Machine Requirements
+
+- `StateMachineLayer` import requires sentinel states to exist: AnyState (`62`), EntryState (`63`), ExitState (`64`)
+- If user spec omits AnyState, builder injects it
+- Transitions must be emitted immediately after their source state

--- a/docs/scene.schema.v1.json
+++ b/docs/scene.schema.v1.json
@@ -1,0 +1,325 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/George-RD/rive-rs-cli/docs/scene.schema.v1.json",
+  "title": "rive-cli SceneSpec v1",
+  "type": "object",
+  "required": ["scene_format_version", "artboard"],
+  "properties": {
+    "scene_format_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "artboard": {
+      "$ref": "#/$defs/artboard"
+    }
+  },
+  "$defs": {
+    "artboard": {
+      "type": "object",
+      "required": ["name", "width", "height", "children"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "width": { "type": "number", "minimum": 0 },
+        "height": { "type": "number", "minimum": 0 },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/object" }
+        },
+        "animations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/animation" }
+        },
+        "state_machines": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/state_machine" }
+        }
+      }
+    },
+    "object": {
+      "oneOf": [
+        { "$ref": "#/$defs/shape" },
+        { "$ref": "#/$defs/ellipse" },
+        { "$ref": "#/$defs/rectangle" },
+        { "$ref": "#/$defs/fill" },
+        { "$ref": "#/$defs/stroke" },
+        { "$ref": "#/$defs/solid_color" },
+        { "$ref": "#/$defs/linear_gradient" },
+        { "$ref": "#/$defs/radial_gradient" },
+        { "$ref": "#/$defs/gradient_stop" },
+        { "$ref": "#/$defs/node" },
+        { "$ref": "#/$defs/path" }
+      ]
+    },
+    "base_object": {
+      "type": "object",
+      "required": ["type", "name"],
+      "properties": {
+        "type": { "type": "string" },
+        "name": { "type": "string", "minLength": 1 }
+      }
+    },
+    "shape": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "properties": {
+            "type": { "const": "shape" },
+            "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
+          }
+        }
+      ]
+    },
+    "ellipse": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "required": ["width", "height"],
+          "properties": {
+            "type": { "const": "ellipse" },
+            "width": { "type": "number", "minimum": 0 },
+            "height": { "type": "number", "minimum": 0 },
+            "origin_x": { "type": "number" },
+            "origin_y": { "type": "number" }
+          }
+        }
+      ]
+    },
+    "rectangle": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "required": ["width", "height"],
+          "properties": {
+            "type": { "const": "rectangle" },
+            "width": { "type": "number", "minimum": 0 },
+            "height": { "type": "number", "minimum": 0 },
+            "corner_radius": { "type": "number", "minimum": 0 },
+            "origin_x": { "type": "number" },
+            "origin_y": { "type": "number" }
+          }
+        }
+      ]
+    },
+    "fill": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "properties": {
+            "type": { "const": "fill" },
+            "fill_rule": { "type": "integer", "minimum": 0 },
+            "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
+          }
+        }
+      ]
+    },
+    "stroke": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "properties": {
+            "type": { "const": "stroke" },
+            "thickness": { "type": "number", "minimum": 0 },
+            "cap": { "type": "integer", "minimum": 0 },
+            "join": { "type": "integer", "minimum": 0 },
+            "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
+          }
+        }
+      ]
+    },
+    "solid_color": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "required": ["color"],
+          "properties": {
+            "type": { "const": "solid_color" },
+            "color": { "type": "string", "pattern": "^#?[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$" }
+          }
+        }
+      ]
+    },
+    "linear_gradient": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "required": ["start_x", "start_y", "end_x", "end_y"],
+          "properties": {
+            "type": { "const": "linear_gradient" },
+            "start_x": { "type": "number" },
+            "start_y": { "type": "number" },
+            "end_x": { "type": "number" },
+            "end_y": { "type": "number" },
+            "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
+          }
+        }
+      ]
+    },
+    "radial_gradient": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "required": ["start_x", "start_y", "end_x", "end_y"],
+          "properties": {
+            "type": { "const": "radial_gradient" },
+            "start_x": { "type": "number" },
+            "start_y": { "type": "number" },
+            "end_x": { "type": "number" },
+            "end_y": { "type": "number" },
+            "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
+          }
+        }
+      ]
+    },
+    "gradient_stop": {
+      "type": "object",
+      "required": ["type", "color", "position"],
+      "properties": {
+        "type": { "const": "gradient_stop" },
+        "name": { "type": "string", "minLength": 1 },
+        "color": { "type": "string", "pattern": "^#?[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$" },
+        "position": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "node": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "properties": {
+            "type": { "const": "node" },
+            "x": { "type": "number" },
+            "y": { "type": "number" }
+          }
+        }
+      ]
+    },
+    "path": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "properties": {
+            "type": { "const": "path" },
+            "path_flags": { "type": "integer", "minimum": 0 }
+          }
+        }
+      ]
+    },
+    "animation": {
+      "type": "object",
+      "required": ["name", "fps", "duration", "keyframes"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "fps": { "type": "integer", "minimum": 1 },
+        "duration": { "type": "integer", "minimum": 1 },
+        "speed": { "type": "number" },
+        "loop_type": { "type": "integer", "minimum": 0 },
+        "keyframes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/keyframe_group" }
+        }
+      }
+    },
+    "keyframe_group": {
+      "type": "object",
+      "required": ["object", "property", "frames"],
+      "properties": {
+        "object": { "type": "string", "minLength": 1 },
+        "property": {
+          "type": "string",
+          "enum": ["x", "y", "rotation", "scale_x", "scale_y", "opacity", "width", "height", "color"]
+        },
+        "frames": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["frame", "value"],
+            "properties": {
+              "frame": { "type": "integer", "minimum": 0 },
+              "value": {}
+            }
+          }
+        }
+      }
+    },
+    "state_machine": {
+      "type": "object",
+      "required": ["name", "layers"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "inputs": { "type": "array", "items": { "$ref": "#/$defs/input" } },
+        "layers": { "type": "array", "items": { "$ref": "#/$defs/layer" } }
+      }
+    },
+    "input": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["type", "name", "value"],
+          "properties": {
+            "type": { "const": "number" },
+            "name": { "type": "string", "minLength": 1 },
+            "value": { "type": "number" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "name", "value"],
+          "properties": {
+            "type": { "const": "bool" },
+            "name": { "type": "string", "minLength": 1 },
+            "value": { "type": "boolean" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "name"],
+          "properties": {
+            "type": { "const": "trigger" },
+            "name": { "type": "string", "minLength": 1 }
+          }
+        }
+      ]
+    },
+    "layer": {
+      "type": "object",
+      "required": ["states"],
+      "properties": {
+        "states": { "type": "array", "items": { "$ref": "#/$defs/state" } },
+        "transitions": { "type": "array", "items": { "$ref": "#/$defs/transition" } }
+      }
+    },
+    "state": {
+      "oneOf": [
+        { "type": "object", "required": ["type"], "properties": { "type": { "const": "entry" } } },
+        { "type": "object", "required": ["type"], "properties": { "type": { "const": "exit" } } },
+        { "type": "object", "required": ["type"], "properties": { "type": { "const": "any" } } },
+        {
+          "type": "object",
+          "required": ["type", "animation"],
+          "properties": {
+            "type": { "const": "animation" },
+            "animation": { "type": "string", "minLength": 1 }
+          }
+        }
+      ]
+    },
+    "transition": {
+      "type": "object",
+      "required": ["from", "to"],
+      "properties": {
+        "from": { "type": "integer", "minimum": 0 },
+        "to": { "type": "integer", "minimum": 0 },
+        "duration": { "type": "integer", "minimum": 0 },
+        "conditions": { "type": "array", "items": { "$ref": "#/$defs/condition" } }
+      }
+    },
+    "condition": {
+      "type": "object",
+      "required": ["input"],
+      "properties": {
+        "input": { "type": "string", "minLength": 1 },
+        "op": { "type": "string" },
+        "value": {}
+      }
+    }
+  }
+}

--- a/docs/scene.schema.v1.json
+++ b/docs/scene.schema.v1.json
@@ -59,8 +59,7 @@
       "properties": {
         "type": { "type": "string" },
         "name": { "type": "string", "minLength": 1 }
-      },
-      "unevaluatedProperties": false
+      }
     },
     "shape": {
       "allOf": [
@@ -70,8 +69,7 @@
           "properties": {
             "type": { "const": "shape" },
             "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
-          },
-          "unevaluatedProperties": false
+          }
         }
       ],
       "unevaluatedProperties": false
@@ -88,8 +86,7 @@
             "height": { "type": "number", "minimum": 0 },
             "origin_x": { "type": "number" },
             "origin_y": { "type": "number" }
-          },
-          "unevaluatedProperties": false
+          }
         }
       ],
       "unevaluatedProperties": false
@@ -107,8 +104,7 @@
             "corner_radius": { "type": "number", "minimum": 0 },
             "origin_x": { "type": "number" },
             "origin_y": { "type": "number" }
-          },
-          "unevaluatedProperties": false
+          }
         }
       ],
       "unevaluatedProperties": false
@@ -122,8 +118,7 @@
             "type": { "const": "fill" },
             "fill_rule": { "type": "integer", "minimum": 0 },
             "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
-          },
-          "unevaluatedProperties": false
+          }
         }
       ],
       "unevaluatedProperties": false
@@ -139,8 +134,7 @@
             "cap": { "type": "integer", "minimum": 0 },
             "join": { "type": "integer", "minimum": 0 },
             "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
-          },
-          "unevaluatedProperties": false
+          }
         }
       ],
       "unevaluatedProperties": false
@@ -154,8 +148,7 @@
           "properties": {
             "type": { "const": "solid_color" },
             "color": { "type": "string", "pattern": "^#?[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$" }
-          },
-          "unevaluatedProperties": false
+          }
         }
       ],
       "unevaluatedProperties": false
@@ -173,8 +166,7 @@
             "end_x": { "type": "number" },
             "end_y": { "type": "number" },
             "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
-          },
-          "unevaluatedProperties": false
+          }
         }
       ],
       "unevaluatedProperties": false
@@ -192,8 +184,7 @@
             "end_x": { "type": "number" },
             "end_y": { "type": "number" },
             "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
-          },
-          "unevaluatedProperties": false
+          }
         }
       ],
       "unevaluatedProperties": false

--- a/docs/scene.schema.v1.json
+++ b/docs/scene.schema.v1.json
@@ -13,6 +13,7 @@
       "$ref": "#/$defs/artboard"
     }
   },
+  "unevaluatedProperties": false,
   "$defs": {
     "artboard": {
       "type": "object",
@@ -33,7 +34,8 @@
           "type": "array",
           "items": { "$ref": "#/$defs/state_machine" }
         }
-      }
+      },
+      "unevaluatedProperties": false
     },
     "object": {
       "oneOf": [
@@ -48,7 +50,8 @@
         { "$ref": "#/$defs/gradient_stop" },
         { "$ref": "#/$defs/node" },
         { "$ref": "#/$defs/path" }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "base_object": {
       "type": "object",
@@ -56,23 +59,28 @@
       "properties": {
         "type": { "type": "string" },
         "name": { "type": "string", "minLength": 1 }
-      }
+      },
+      "unevaluatedProperties": false
     },
     "shape": {
       "allOf": [
         { "$ref": "#/$defs/base_object" },
         {
+          "type": "object",
           "properties": {
             "type": { "const": "shape" },
             "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "ellipse": {
       "allOf": [
         { "$ref": "#/$defs/base_object" },
         {
+          "type": "object",
           "required": ["width", "height"],
           "properties": {
             "type": { "const": "ellipse" },
@@ -80,14 +88,17 @@
             "height": { "type": "number", "minimum": 0 },
             "origin_x": { "type": "number" },
             "origin_y": { "type": "number" }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "rectangle": {
       "allOf": [
         { "$ref": "#/$defs/base_object" },
         {
+          "type": "object",
           "required": ["width", "height"],
           "properties": {
             "type": { "const": "rectangle" },
@@ -96,52 +107,64 @@
             "corner_radius": { "type": "number", "minimum": 0 },
             "origin_x": { "type": "number" },
             "origin_y": { "type": "number" }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "fill": {
       "allOf": [
         { "$ref": "#/$defs/base_object" },
         {
+          "type": "object",
           "properties": {
             "type": { "const": "fill" },
             "fill_rule": { "type": "integer", "minimum": 0 },
             "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "stroke": {
       "allOf": [
         { "$ref": "#/$defs/base_object" },
         {
+          "type": "object",
           "properties": {
             "type": { "const": "stroke" },
             "thickness": { "type": "number", "minimum": 0 },
             "cap": { "type": "integer", "minimum": 0 },
             "join": { "type": "integer", "minimum": 0 },
             "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "solid_color": {
       "allOf": [
         { "$ref": "#/$defs/base_object" },
         {
+          "type": "object",
           "required": ["color"],
           "properties": {
             "type": { "const": "solid_color" },
             "color": { "type": "string", "pattern": "^#?[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$" }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "linear_gradient": {
       "allOf": [
         { "$ref": "#/$defs/base_object" },
         {
+          "type": "object",
           "required": ["start_x", "start_y", "end_x", "end_y"],
           "properties": {
             "type": { "const": "linear_gradient" },
@@ -150,14 +173,17 @@
             "end_x": { "type": "number" },
             "end_y": { "type": "number" },
             "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "radial_gradient": {
       "allOf": [
         { "$ref": "#/$defs/base_object" },
         {
+          "type": "object",
           "required": ["start_x", "start_y", "end_x", "end_y"],
           "properties": {
             "type": { "const": "radial_gradient" },
@@ -166,9 +192,11 @@
             "end_x": { "type": "number" },
             "end_y": { "type": "number" },
             "children": { "type": "array", "items": { "$ref": "#/$defs/object" } }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "gradient_stop": {
       "type": "object",
@@ -178,30 +206,37 @@
         "name": { "type": "string", "minLength": 1 },
         "color": { "type": "string", "pattern": "^#?[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$" },
         "position": { "type": "number", "minimum": 0, "maximum": 1 }
-      }
+      },
+      "unevaluatedProperties": false
     },
     "node": {
       "allOf": [
         { "$ref": "#/$defs/base_object" },
         {
+          "type": "object",
           "properties": {
             "type": { "const": "node" },
             "x": { "type": "number" },
             "y": { "type": "number" }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "path": {
       "allOf": [
         { "$ref": "#/$defs/base_object" },
         {
+          "type": "object",
           "properties": {
             "type": { "const": "path" },
             "path_flags": { "type": "integer", "minimum": 0 }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "animation": {
       "type": "object",
@@ -216,7 +251,8 @@
           "type": "array",
           "items": { "$ref": "#/$defs/keyframe_group" }
         }
-      }
+      },
+      "unevaluatedProperties": false
     },
     "keyframe_group": {
       "type": "object",
@@ -235,10 +271,12 @@
             "properties": {
               "frame": { "type": "integer", "minimum": 0 },
               "value": {}
-            }
+            },
+            "unevaluatedProperties": false
           }
         }
-      }
+      },
+      "unevaluatedProperties": false
     },
     "state_machine": {
       "type": "object",
@@ -247,7 +285,8 @@
         "name": { "type": "string", "minLength": 1 },
         "inputs": { "type": "array", "items": { "$ref": "#/$defs/input" } },
         "layers": { "type": "array", "items": { "$ref": "#/$defs/layer" } }
-      }
+      },
+      "unevaluatedProperties": false
     },
     "input": {
       "oneOf": [
@@ -258,7 +297,8 @@
             "type": { "const": "number" },
             "name": { "type": "string", "minLength": 1 },
             "value": { "type": "number" }
-          }
+          },
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -267,7 +307,8 @@
             "type": { "const": "bool" },
             "name": { "type": "string", "minLength": 1 },
             "value": { "type": "boolean" }
-          }
+          },
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -275,9 +316,11 @@
           "properties": {
             "type": { "const": "trigger" },
             "name": { "type": "string", "minLength": 1 }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "layer": {
       "type": "object",
@@ -285,22 +328,40 @@
       "properties": {
         "states": { "type": "array", "items": { "$ref": "#/$defs/state" } },
         "transitions": { "type": "array", "items": { "$ref": "#/$defs/transition" } }
-      }
+      },
+      "unevaluatedProperties": false
     },
     "state": {
       "oneOf": [
-        { "type": "object", "required": ["type"], "properties": { "type": { "const": "entry" } } },
-        { "type": "object", "required": ["type"], "properties": { "type": { "const": "exit" } } },
-        { "type": "object", "required": ["type"], "properties": { "type": { "const": "any" } } },
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": { "type": { "const": "entry" } },
+          "unevaluatedProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": { "type": { "const": "exit" } },
+          "unevaluatedProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": { "type": { "const": "any" } },
+          "unevaluatedProperties": false
+        },
         {
           "type": "object",
           "required": ["type", "animation"],
           "properties": {
             "type": { "const": "animation" },
             "animation": { "type": "string", "minLength": 1 }
-          }
+          },
+          "unevaluatedProperties": false
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "transition": {
       "type": "object",
@@ -310,7 +371,8 @@
         "to": { "type": "integer", "minimum": 0 },
         "duration": { "type": "integer", "minimum": 0 },
         "conditions": { "type": "array", "items": { "$ref": "#/$defs/condition" } }
-      }
+      },
+      "unevaluatedProperties": false
     },
     "condition": {
       "type": "object",
@@ -319,7 +381,8 @@
         "input": { "type": "string", "minLength": 1 },
         "op": { "type": "string" },
         "value": {}
-      }
+      },
+      "unevaluatedProperties": false
     }
   }
 }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,2 +1,2 @@
 pub mod scene;
-pub use scene::{build_scene, SceneSpec};
+pub use scene::{SceneSpec, build_scene};

--- a/src/builder/scene.rs
+++ b/src/builder/scene.rs
@@ -22,13 +22,8 @@ const SCENE_FORMAT_VERSION: u32 = 1;
 
 #[derive(Debug, Deserialize)]
 pub struct SceneSpec {
-    #[serde(default = "default_scene_format_version")]
     pub scene_format_version: u32,
     pub artboard: ArtboardSpec,
-}
-
-fn default_scene_format_version() -> u32 {
-    SCENE_FORMAT_VERSION
 }
 
 #[derive(Debug, Deserialize)]
@@ -976,6 +971,7 @@ mod tests {
     #[test]
     fn test_parse_minimal_json() {
         let json = r#"{
+            "scene_format_version": 1,
             "artboard": {
                 "name": "Main",
                 "width": 500.0,
@@ -1016,6 +1012,7 @@ mod tests {
     #[test]
     fn test_parse_shape_with_fill() {
         let json = r#"{
+            "scene_format_version": 1,
             "artboard": {
                 "name": "Main",
                 "width": 100.0,

--- a/src/builder/scene.rs
+++ b/src/builder/scene.rs
@@ -663,7 +663,10 @@ fn json_value_to_f32(value: &serde_json::Value) -> Option<f32> {
 fn json_value_to_color(value: &serde_json::Value) -> Option<u32> {
     match value {
         serde_json::Value::String(s) => parse_color(s).ok(),
-        serde_json::Value::Number(n) => n.as_u64().map(|v| v as u32),
+        serde_json::Value::Number(n) => n
+            .as_u64()
+            .filter(|&v| v <= u32::MAX as u64)
+            .map(|v| v as u32),
         _ => None,
     }
 }
@@ -1330,5 +1333,11 @@ mod tests {
 
         let objects = build_scene(&spec).unwrap();
         assert!(objects.len() >= 4);
+    }
+
+    #[test]
+    fn test_json_value_to_color_rejects_overflow() {
+        let value = serde_json::json!(4294967296u64);
+        assert!(json_value_to_color(&value).is_none());
     }
 }

--- a/src/builder/scene.rs
+++ b/src/builder/scene.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::Deserialize;
 
@@ -8,8 +8,8 @@ use crate::objects::animation::{
 use crate::objects::artboard::{Artboard, Backboard};
 use crate::objects::core::RiveObject;
 use crate::objects::shapes::{
-    Ellipse, Fill, GradientStop, LinearGradient, Node, RadialGradient, Rectangle, Shape,
-    SolidColor, Stroke,
+    Ellipse, Fill, GradientStop, LinearGradient, Node, PathObject, RadialGradient, Rectangle,
+    Shape, SolidColor, Stroke,
 };
 use crate::objects::state_machine::{
     AnimationState, AnyState, EntryState, ExitState, StateMachine, StateMachineBool,
@@ -18,9 +18,17 @@ use crate::objects::state_machine::{
     TransitionTriggerCondition, TransitionValueCondition,
 };
 
+const SCENE_FORMAT_VERSION: u32 = 1;
+
 #[derive(Debug, Deserialize)]
 pub struct SceneSpec {
+    #[serde(default = "default_scene_format_version")]
+    pub scene_format_version: u32,
     pub artboard: ArtboardSpec,
+}
+
+fn default_scene_format_version() -> u32 {
+    SCENE_FORMAT_VERSION
 }
 
 #[derive(Debug, Deserialize)]
@@ -97,6 +105,10 @@ pub enum ObjectSpec {
         x: Option<f32>,
         y: Option<f32>,
     },
+    Path {
+        name: String,
+        path_flags: Option<u64>,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -167,7 +179,9 @@ pub struct ConditionSpec {
     pub value: Option<serde_json::Value>,
 }
 
-pub fn build_scene(spec: &SceneSpec) -> Vec<Box<dyn RiveObject>> {
+pub fn build_scene(spec: &SceneSpec) -> Result<Vec<Box<dyn RiveObject>>, String> {
+    validate_scene_spec(spec)?;
+
     let mut objects: Vec<Box<dyn RiveObject>> = Vec::new();
     let mut object_name_to_index: HashMap<String, usize> = HashMap::new();
     let mut animation_name_to_index: HashMap<String, usize> = HashMap::new();
@@ -189,7 +203,7 @@ pub fn build_scene(spec: &SceneSpec) -> Vec<Box<dyn RiveObject>> {
     objects.push(Box::new(artboard));
 
     for child in &spec.artboard.children {
-        append_object(child, 1, &mut objects, &mut object_name_to_index);
+        append_object(child, 1, &mut objects, &mut object_name_to_index)?;
     }
 
     if let Some(animations) = &spec.artboard.animations {
@@ -207,29 +221,39 @@ pub fn build_scene(spec: &SceneSpec) -> Vec<Box<dyn RiveObject>> {
             animation_name_to_index.insert(animation.name.clone(), animation_list_index);
 
             for group in &animation.keyframes {
-                let object_index = *object_name_to_index.get(&group.object).unwrap_or_else(|| {
-                    panic!("unknown object referenced in keyframes: '{}'", group.object)
-                });
+                let object_index = *object_name_to_index.get(&group.object).ok_or_else(|| {
+                    format!("unknown object referenced in keyframes: '{}'", group.object)
+                })?;
                 objects.push(Box::new(KeyedObject {
                     object_id: (object_index - 1) as u64,
                 }));
 
-                let property_key = property_key_from_name(&group.property).unwrap_or_else(|| {
-                    panic!(
+                let property_key = property_key_from_name(&group.property).ok_or_else(|| {
+                    format!(
                         "unknown property referenced in keyframes: '{}'",
                         group.property
                     )
-                });
+                })?;
                 objects.push(Box::new(KeyedProperty {
                     property_key: property_key as u64,
                 }));
 
                 for frame in &group.frames {
                     if property_key == 37 {
-                        if let Some(color) = json_value_to_color(&frame.value) {
-                            objects.push(Box::new(KeyFrameColor::new(frame.frame, color)));
-                        }
-                    } else if let Some(value) = json_value_to_f32(&frame.value) {
+                        let color = json_value_to_color(&frame.value).ok_or_else(|| {
+                            format!(
+                                "invalid color keyframe value for object '{}' property '{}' at frame {}",
+                                group.object, group.property, frame.frame
+                            )
+                        })?;
+                        objects.push(Box::new(KeyFrameColor::new(frame.frame, color)));
+                    } else {
+                        let value = json_value_to_f32(&frame.value).ok_or_else(|| {
+                            format!(
+                                "invalid numeric keyframe value for object '{}' property '{}' at frame {}",
+                                group.object, group.property, frame.frame
+                            )
+                        })?;
                         objects.push(Box::new(KeyFrameDouble::new(frame.frame, value)));
                     }
                 }
@@ -298,9 +322,9 @@ pub fn build_scene(spec: &SceneSpec) -> Vec<Box<dyn RiveObject>> {
                         }
                         StateSpec::Animation { animation } => {
                             let animation_id =
-                                *animation_name_to_index.get(animation).unwrap_or_else(|| {
-                                    panic!("unknown animation referenced: '{}'", animation)
-                                }) as u64;
+                                *animation_name_to_index.get(animation).ok_or_else(|| {
+                                    format!("unknown animation referenced: '{}'", animation)
+                                })? as u64;
                             objects.push(Box::new(AnimationState::new(animation_id)));
                         }
                     }
@@ -310,14 +334,13 @@ pub fn build_scene(spec: &SceneSpec) -> Vec<Box<dyn RiveObject>> {
                             if transition.from != user_idx {
                                 continue;
                             }
-                            let state_to_id =
-                                *user_to_final.get(transition.to).unwrap_or_else(|| {
-                                    panic!(
-                                        "transition target index {} out of bounds (layer has {} states)",
-                                        transition.to,
-                                        user_to_final.len()
-                                    )
-                                }) as u64;
+                            let state_to_id = *user_to_final.get(transition.to).ok_or_else(|| {
+                                format!(
+                                    "transition target index {} out of bounds (layer has {} states)",
+                                    transition.to,
+                                    user_to_final.len()
+                                )
+                            })? as u64;
                             let mut state_transition = StateTransition::new(state_to_id);
                             if let Some(duration) = transition.duration {
                                 state_transition.duration = duration;
@@ -328,12 +351,12 @@ pub fn build_scene(spec: &SceneSpec) -> Vec<Box<dyn RiveObject>> {
                                 for condition in conditions {
                                     let input_index = *input_name_to_index
                                         .get(&condition.input)
-                                        .unwrap_or_else(|| {
-                                            panic!(
+                                        .ok_or_else(|| {
+                                            format!(
                                                 "unknown input referenced in condition: '{}'",
                                                 condition.input
                                             )
-                                        });
+                                        })?;
                                     {
                                         let input_id = input_index as u64;
                                         let op = condition
@@ -347,7 +370,12 @@ pub fn build_scene(spec: &SceneSpec) -> Vec<Box<dyn RiveObject>> {
                                                     .value
                                                     .as_ref()
                                                     .and_then(json_value_to_f32)
-                                                    .unwrap_or(0.0);
+                                                    .ok_or_else(|| {
+                                                        format!(
+                                                            "invalid numeric condition value for input '{}'",
+                                                            condition.input
+                                                        )
+                                                    })?;
                                                 objects.push(Box::new(
                                                     TransitionNumberCondition::new(
                                                         input_id, op, value,
@@ -393,7 +421,7 @@ pub fn build_scene(spec: &SceneSpec) -> Vec<Box<dyn RiveObject>> {
         }
     }
 
-    objects
+    Ok(objects)
 }
 
 fn append_object(
@@ -401,7 +429,7 @@ fn append_object(
     parent_index: usize,
     objects: &mut Vec<Box<dyn RiveObject>>,
     name_to_index: &mut HashMap<String, usize>,
-) {
+) -> Result<(), String> {
     let object_index = objects.len();
     let parent_id = (parent_index - 1) as u64;
 
@@ -411,7 +439,7 @@ fn append_object(
             name_to_index.insert(name.clone(), object_index);
             if let Some(children) = children {
                 for child in children {
-                    append_object(child, object_index, objects, name_to_index);
+                    append_object(child, object_index, objects, name_to_index)?;
                 }
             }
         }
@@ -470,7 +498,7 @@ fn append_object(
             name_to_index.insert(name.clone(), object_index);
             if let Some(children) = children {
                 for child in children {
-                    append_object(child, object_index, objects, name_to_index);
+                    append_object(child, object_index, objects, name_to_index)?;
                 }
             }
         }
@@ -492,12 +520,12 @@ fn append_object(
             name_to_index.insert(name.clone(), object_index);
             if let Some(children) = children {
                 for child in children {
-                    append_object(child, object_index, objects, name_to_index);
+                    append_object(child, object_index, objects, name_to_index)?;
                 }
             }
         }
         ObjectSpec::SolidColor { name, color } => {
-            let color_value = parse_color(color).unwrap_or(0);
+            let color_value = parse_color(color)?;
             objects.push(Box::new(SolidColor::new(
                 name.clone(),
                 parent_id,
@@ -525,7 +553,7 @@ fn append_object(
             name_to_index.insert(name.clone(), object_index);
             if let Some(children) = children {
                 for child in children {
-                    append_object(child, object_index, objects, name_to_index);
+                    append_object(child, object_index, objects, name_to_index)?;
                 }
             }
         }
@@ -549,7 +577,7 @@ fn append_object(
             name_to_index.insert(name.clone(), object_index);
             if let Some(children) = children {
                 for child in children {
-                    append_object(child, object_index, objects, name_to_index);
+                    append_object(child, object_index, objects, name_to_index)?;
                 }
             }
         }
@@ -564,7 +592,7 @@ fn append_object(
             objects.push(Box::new(GradientStop {
                 name: generated_name.clone(),
                 parent_id,
-                color: parse_color(color).unwrap_or(0),
+                color: parse_color(color)?,
                 position: *position,
             }));
             name_to_index.insert(generated_name, object_index);
@@ -578,7 +606,17 @@ fn append_object(
             }));
             name_to_index.insert(name.clone(), object_index);
         }
+        ObjectSpec::Path { name, path_flags } => {
+            objects.push(Box::new(PathObject {
+                name: name.clone(),
+                parent_id,
+                path_flags: path_flags.unwrap_or(0),
+            }));
+            name_to_index.insert(name.clone(), object_index);
+        }
     }
+
+    Ok(())
 }
 
 fn property_key_from_name(name: &str) -> Option<u16> {
@@ -596,9 +634,23 @@ fn property_key_from_name(name: &str) -> Option<u16> {
     }
 }
 
-fn parse_color(color: &str) -> Option<u32> {
+fn parse_color(color: &str) -> Result<u32, String> {
     let hex = color.trim_start_matches('#');
-    u32::from_str_radix(hex, 16).ok()
+    if hex.len() == 8 {
+        return u32::from_str_radix(hex, 16)
+            .map_err(|_| format!("invalid 8-digit color literal: '{}'", color));
+    }
+
+    if hex.len() == 6 {
+        return u32::from_str_radix(hex, 16)
+            .map(|rgb| 0xFF00_0000 | rgb)
+            .map_err(|_| format!("invalid 6-digit color literal: '{}'", color));
+    }
+
+    Err(format!(
+        "invalid color literal '{}' (expected 6 or 8 hex digits)",
+        color
+    ))
 }
 
 fn json_value_to_f32(value: &serde_json::Value) -> Option<f32> {
@@ -610,10 +662,282 @@ fn json_value_to_f32(value: &serde_json::Value) -> Option<f32> {
 
 fn json_value_to_color(value: &serde_json::Value) -> Option<u32> {
     match value {
-        serde_json::Value::String(s) => parse_color(s),
+        serde_json::Value::String(s) => parse_color(s).ok(),
         serde_json::Value::Number(n) => n.as_u64().map(|v| v as u32),
         _ => None,
     }
+}
+
+fn validate_scene_spec(spec: &SceneSpec) -> Result<(), String> {
+    if spec.scene_format_version != SCENE_FORMAT_VERSION {
+        return Err(format!(
+            "unsupported scene_format_version {} (expected {})",
+            spec.scene_format_version, SCENE_FORMAT_VERSION
+        ));
+    }
+
+    if spec.artboard.width < 0.0 {
+        return Err("artboard width must be non-negative".to_string());
+    }
+    if spec.artboard.height < 0.0 {
+        return Err("artboard height must be non-negative".to_string());
+    }
+
+    let mut object_names: HashSet<String> = HashSet::new();
+    for child in &spec.artboard.children {
+        validate_object_spec(child, &mut object_names)?;
+    }
+
+    let mut animation_names: HashSet<String> = HashSet::new();
+    if let Some(animations) = &spec.artboard.animations {
+        for animation in animations {
+            if animation.duration == 0 {
+                return Err(format!(
+                    "animation '{}' duration must be greater than 0",
+                    animation.name
+                ));
+            }
+            if animation_names.contains(&animation.name) {
+                return Err(format!("duplicate animation name '{}'", animation.name));
+            }
+            animation_names.insert(animation.name.clone());
+
+            for group in &animation.keyframes {
+                if !object_names.contains(&group.object) {
+                    return Err(format!(
+                        "unknown object referenced in keyframes: '{}'",
+                        group.object
+                    ));
+                }
+                let property_key = property_key_from_name(&group.property).ok_or_else(|| {
+                    format!(
+                        "unknown property referenced in keyframes: '{}'",
+                        group.property
+                    )
+                })?;
+
+                for frame in &group.frames {
+                    if property_key == 37 {
+                        if json_value_to_color(&frame.value).is_none() {
+                            return Err(format!(
+                                "invalid color keyframe value for object '{}' property '{}' at frame {}",
+                                group.object, group.property, frame.frame
+                            ));
+                        }
+                    } else if json_value_to_f32(&frame.value).is_none() {
+                        return Err(format!(
+                            "invalid numeric keyframe value for object '{}' property '{}' at frame {}",
+                            group.object, group.property, frame.frame
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(state_machines) = &spec.artboard.state_machines {
+        for state_machine in state_machines {
+            let mut input_names: HashSet<String> = HashSet::new();
+            if let Some(inputs) = &state_machine.inputs {
+                for input in inputs {
+                    let name = match input {
+                        InputSpec::Number { name, .. } => name,
+                        InputSpec::Bool { name, .. } => name,
+                        InputSpec::Trigger { name } => name,
+                    };
+                    if input_names.contains(name) {
+                        return Err(format!(
+                            "duplicate state machine input '{}' in '{}'",
+                            name, state_machine.name
+                        ));
+                    }
+                    input_names.insert(name.clone());
+                }
+            }
+
+            for layer in &state_machine.layers {
+                for state in &layer.states {
+                    if let StateSpec::Animation { animation } = state
+                        && !animation_names.contains(animation)
+                    {
+                        return Err(format!(
+                            "unknown animation referenced in state machine '{}': '{}'",
+                            state_machine.name, animation
+                        ));
+                    }
+                }
+
+                if let Some(transitions) = &layer.transitions {
+                    for transition in transitions {
+                        if transition.from >= layer.states.len() {
+                            return Err(format!(
+                                "transition source index {} out of bounds (layer has {} states)",
+                                transition.from,
+                                layer.states.len()
+                            ));
+                        }
+                        if transition.to >= layer.states.len() {
+                            return Err(format!(
+                                "transition target index {} out of bounds (layer has {} states)",
+                                transition.to,
+                                layer.states.len()
+                            ));
+                        }
+
+                        if let Some(conditions) = &transition.conditions {
+                            for condition in conditions {
+                                if !input_names.contains(&condition.input) {
+                                    return Err(format!(
+                                        "unknown input referenced in condition: '{}'",
+                                        condition.input
+                                    ));
+                                }
+                                if let Some(serde_json::Value::String(color)) =
+                                    condition.value.as_ref()
+                                {
+                                    parse_color(color)?;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_object_spec(
+    spec: &ObjectSpec,
+    object_names: &mut HashSet<String>,
+) -> Result<(), String> {
+    match spec {
+        ObjectSpec::Shape { name, children } => {
+            ensure_unique_name(name, object_names)?;
+            if let Some(children) = children {
+                for child in children {
+                    validate_object_spec(child, object_names)?;
+                }
+            }
+        }
+        ObjectSpec::Ellipse {
+            name,
+            width,
+            height,
+            ..
+        } => {
+            ensure_unique_name(name, object_names)?;
+            if *width < 0.0 {
+                return Err(format!("ellipse '{}' width must be non-negative", name));
+            }
+            if *height < 0.0 {
+                return Err(format!("ellipse '{}' height must be non-negative", name));
+            }
+        }
+        ObjectSpec::Rectangle {
+            name,
+            width,
+            height,
+            corner_radius,
+            ..
+        } => {
+            ensure_unique_name(name, object_names)?;
+            if *width < 0.0 {
+                return Err(format!("rectangle '{}' width must be non-negative", name));
+            }
+            if *height < 0.0 {
+                return Err(format!("rectangle '{}' height must be non-negative", name));
+            }
+            if let Some(corner_radius) = corner_radius
+                && *corner_radius < 0.0
+            {
+                return Err(format!(
+                    "rectangle '{}' corner_radius must be non-negative",
+                    name
+                ));
+            }
+        }
+        ObjectSpec::Fill { name, children, .. } => {
+            ensure_unique_name(name, object_names)?;
+            if let Some(children) = children {
+                for child in children {
+                    validate_object_spec(child, object_names)?;
+                }
+            }
+        }
+        ObjectSpec::Stroke {
+            name,
+            thickness,
+            children,
+            ..
+        } => {
+            ensure_unique_name(name, object_names)?;
+            if let Some(thickness) = thickness
+                && *thickness < 0.0
+            {
+                return Err(format!("stroke '{}' thickness must be non-negative", name));
+            }
+            if let Some(children) = children {
+                for child in children {
+                    validate_object_spec(child, object_names)?;
+                }
+            }
+        }
+        ObjectSpec::SolidColor { name, color } => {
+            ensure_unique_name(name, object_names)?;
+            parse_color(color)?;
+        }
+        ObjectSpec::LinearGradient { name, children, .. } => {
+            ensure_unique_name(name, object_names)?;
+            if let Some(children) = children {
+                for child in children {
+                    validate_object_spec(child, object_names)?;
+                }
+            }
+        }
+        ObjectSpec::RadialGradient { name, children, .. } => {
+            ensure_unique_name(name, object_names)?;
+            if let Some(children) = children {
+                for child in children {
+                    validate_object_spec(child, object_names)?;
+                }
+            }
+        }
+        ObjectSpec::GradientStop {
+            name,
+            color,
+            position,
+        } => {
+            let effective_name = name
+                .clone()
+                .unwrap_or_else(|| format!("gradient_stop_{}", object_names.len()));
+            ensure_unique_name(&effective_name, object_names)?;
+            parse_color(color)?;
+            if !(0.0..=1.0).contains(position) {
+                return Err(format!(
+                    "gradient stop '{}' position must be between 0 and 1",
+                    effective_name
+                ));
+            }
+        }
+        ObjectSpec::Node { name, .. } => {
+            ensure_unique_name(name, object_names)?;
+        }
+        ObjectSpec::Path { name, .. } => {
+            ensure_unique_name(name, object_names)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_unique_name(name: &str, object_names: &mut HashSet<String>) -> Result<(), String> {
+    if object_names.contains(name) {
+        return Err(format!("duplicate object name '{}'", name));
+    }
+    object_names.insert(name.to_string());
+    Ok(())
 }
 
 fn parse_condition_op(op: &str) -> u64 {
@@ -631,10 +955,10 @@ fn parse_condition_op(op: &str) -> u64 {
 fn input_is_trigger(input_name: &str, inputs: Option<&Vec<InputSpec>>) -> bool {
     if let Some(inputs) = inputs {
         for input in inputs {
-            if let InputSpec::Trigger { name } = input {
-                if name == input_name {
-                    return true;
-                }
+            if let InputSpec::Trigger { name } = input
+                && name == input_name
+            {
+                return true;
             }
         }
     }
@@ -644,7 +968,7 @@ fn input_is_trigger(input_name: &str, inputs: Option<&Vec<InputSpec>>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::objects::core::{property_keys, type_keys, PropertyValue};
+    use crate::objects::core::{PropertyValue, property_keys, type_keys};
 
     #[test]
     fn test_parse_minimal_json() {
@@ -662,6 +986,28 @@ mod tests {
         assert_eq!(scene.artboard.width, 500.0);
         assert_eq!(scene.artboard.children.len(), 0);
         assert!(scene.artboard.animations.is_none());
+        assert_eq!(scene.scene_format_version, 1);
+    }
+
+    #[test]
+    fn test_reject_unsupported_scene_format_version() {
+        let spec = SceneSpec {
+            scene_format_version: 2,
+            artboard: ArtboardSpec {
+                name: "Main".to_string(),
+                width: 500.0,
+                height: 500.0,
+                children: vec![],
+                animations: None,
+                state_machines: None,
+            },
+        };
+
+        let err = match build_scene(&spec) {
+            Ok(_) => panic!("expected scene format version error"),
+            Err(err) => err,
+        };
+        assert!(err.contains("unsupported scene_format_version 2"));
     }
 
     #[test]
@@ -713,6 +1059,7 @@ mod tests {
     #[test]
     fn test_build_minimal_scene() {
         let spec = SceneSpec {
+            scene_format_version: 1,
             artboard: ArtboardSpec {
                 name: "Main".to_string(),
                 width: 500.0,
@@ -723,20 +1070,23 @@ mod tests {
             },
         };
 
-        let objects = build_scene(&spec);
+        let objects = build_scene(&spec).unwrap();
         assert_eq!(objects.len(), 2);
         assert_eq!(objects[0].type_key(), type_keys::BACKBOARD);
         assert_eq!(objects[1].type_key(), type_keys::ARTBOARD);
 
         let artboard_props = objects[1].properties();
-        assert!(!artboard_props
-            .iter()
-            .any(|p| p.key == property_keys::COMPONENT_PARENT_ID));
+        assert!(
+            !artboard_props
+                .iter()
+                .any(|p| p.key == property_keys::COMPONENT_PARENT_ID)
+        );
     }
 
     #[test]
     fn test_build_scene_with_shape() {
         let spec = SceneSpec {
+            scene_format_version: 1,
             artboard: ArtboardSpec {
                 name: "Main".to_string(),
                 width: 500.0,
@@ -766,7 +1116,7 @@ mod tests {
             },
         };
 
-        let objects = build_scene(&spec);
+        let objects = build_scene(&spec).unwrap();
         assert_eq!(objects.len(), 6);
         assert_eq!(objects[0].type_key(), type_keys::BACKBOARD);
         assert_eq!(objects[1].type_key(), type_keys::ARTBOARD);
@@ -807,6 +1157,7 @@ mod tests {
     #[test]
     fn test_build_scene_with_animation() {
         let spec = SceneSpec {
+            scene_format_version: 1,
             artboard: ArtboardSpec {
                 name: "Main".to_string(),
                 width: 500.0,
@@ -846,7 +1197,7 @@ mod tests {
             },
         };
 
-        let objects = build_scene(&spec);
+        let objects = build_scene(&spec).unwrap();
         assert_eq!(objects[0].type_key(), type_keys::BACKBOARD);
         assert_eq!(objects[1].type_key(), type_keys::ARTBOARD);
         assert_eq!(objects[2].type_key(), type_keys::SHAPE);
@@ -863,5 +1214,89 @@ mod tests {
             .find(|p| p.key == property_keys::KEYED_OBJECT_ID)
             .unwrap();
         assert_eq!(keyed_object_id.value, PropertyValue::UInt(2));
+    }
+
+    #[test]
+    fn test_build_scene_rejects_invalid_color() {
+        let spec = SceneSpec {
+            scene_format_version: 1,
+            artboard: ArtboardSpec {
+                name: "Main".to_string(),
+                width: 100.0,
+                height: 100.0,
+                children: vec![ObjectSpec::SolidColor {
+                    name: "bad_color".to_string(),
+                    color: "not-a-color".to_string(),
+                }],
+                animations: None,
+                state_machines: None,
+            },
+        };
+
+        let err = match build_scene(&spec) {
+            Ok(_) => panic!("expected invalid color error"),
+            Err(err) => err,
+        };
+        assert!(err.contains("invalid color literal"));
+    }
+
+    #[test]
+    fn test_build_scene_rejects_oob_transition_index() {
+        let spec = SceneSpec {
+            scene_format_version: 1,
+            artboard: ArtboardSpec {
+                name: "Main".to_string(),
+                width: 100.0,
+                height: 100.0,
+                children: vec![],
+                animations: None,
+                state_machines: Some(vec![StateMachineSpec {
+                    name: "sm".to_string(),
+                    inputs: None,
+                    layers: vec![LayerSpec {
+                        states: vec![StateSpec::Entry, StateSpec::Exit],
+                        transitions: Some(vec![TransitionSpec {
+                            from: 0,
+                            to: 3,
+                            duration: None,
+                            conditions: None,
+                        }]),
+                    }],
+                }]),
+            },
+        };
+
+        let err = match build_scene(&spec) {
+            Ok(_) => panic!("expected out-of-bounds transition error"),
+            Err(err) => err,
+        };
+        assert!(err.contains("transition target index 3 out of bounds"));
+    }
+
+    #[test]
+    fn test_build_scene_with_path_object() {
+        let spec = SceneSpec {
+            scene_format_version: 1,
+            artboard: ArtboardSpec {
+                name: "Main".to_string(),
+                width: 100.0,
+                height: 100.0,
+                children: vec![ObjectSpec::Path {
+                    name: "path_1".to_string(),
+                    path_flags: Some(3),
+                }],
+                animations: None,
+                state_machines: None,
+            },
+        };
+
+        let objects = build_scene(&spec).unwrap();
+        assert_eq!(objects[2].type_key(), type_keys::PATH);
+        let path_flags = objects[2]
+            .properties()
+            .into_iter()
+            .find(|p| p.key == property_keys::PATH_FLAGS)
+            .unwrap();
+        assert_eq!(path_flags.value, PropertyValue::UInt(3));
     }
 }

--- a/src/builder/scene.rs
+++ b/src/builder/scene.rs
@@ -588,7 +588,7 @@ fn append_object(
         } => {
             let generated_name = name
                 .clone()
-                .unwrap_or_else(|| format!("gradient_stop_{}", object_index));
+                .unwrap_or_else(|| format!("gradient_stop_{}", name_to_index.len()));
             objects.push(Box::new(GradientStop {
                 name: generated_name.clone(),
                 parent_id,
@@ -1298,5 +1298,37 @@ mod tests {
             .find(|p| p.key == property_keys::PATH_FLAGS)
             .unwrap();
         assert_eq!(path_flags.value, PropertyValue::UInt(3));
+    }
+
+    #[test]
+    fn test_gradient_stop_generated_name_alignment() {
+        let spec = SceneSpec {
+            scene_format_version: 1,
+            artboard: ArtboardSpec {
+                name: "Main".to_string(),
+                width: 100.0,
+                height: 100.0,
+                children: vec![ObjectSpec::Shape {
+                    name: "shape_1".to_string(),
+                    children: Some(vec![
+                        ObjectSpec::GradientStop {
+                            name: Some("gradient_stop_1".to_string()),
+                            color: "FFFFFFFF".to_string(),
+                            position: 0.0,
+                        },
+                        ObjectSpec::GradientStop {
+                            name: None,
+                            color: "FF000000".to_string(),
+                            position: 1.0,
+                        },
+                    ]),
+                }],
+                animations: None,
+                state_machines: None,
+            },
+        };
+
+        let objects = build_scene(&spec).unwrap();
+        assert!(objects.len() >= 4);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,18 +11,21 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Command {
     Generate {
+        #[arg(help = "Path to the JSON scene input")]
         input: PathBuf,
-        #[arg(short, long, default_value = "output.riv")]
+        #[arg(short, long, default_value = "output.riv", help = "Output .riv path")]
         output: PathBuf,
-        #[arg(long, default_value = "0")]
+        #[arg(long, default_value = "0", help = "Rive file id written in header")]
         file_id: u64,
     },
     Validate {
+        #[arg(help = "Path to .riv file to validate")]
         file: PathBuf,
     },
     Inspect {
+        #[arg(help = "Path to .riv file to inspect")]
         file: PathBuf,
-        #[arg(long)]
+        #[arg(long, help = "Output parsed result as JSON")]
         json: bool,
     },
 }

--- a/src/encoder/toc.rs
+++ b/src/encoder/toc.rs
@@ -1,5 +1,14 @@
 use super::binary_writer::BinaryWriter;
-use crate::objects::core::property_backing_type;
+use crate::objects::core::{BackingType, property_backing_type};
+
+fn backing_bits(backing_type: BackingType) -> u32 {
+    match backing_type {
+        BackingType::UInt => 0,
+        BackingType::String => 1,
+        BackingType::Float => 2,
+        BackingType::Color => 3,
+    }
+}
 
 pub fn encode_toc(property_keys: &[u16]) -> Vec<u8> {
     let mut writer = BinaryWriter::new();
@@ -10,7 +19,7 @@ pub fn encode_toc(property_keys: &[u16]) -> Vec<u8> {
     writer.write_varuint(0);
 
     if !property_keys.is_empty() {
-        let num_uint32s = (property_keys.len() + 15) / 16;
+        let num_uint32s = property_keys.len().div_ceil(16);
         for chunk in 0..num_uint32s {
             let mut val: u32 = 0;
             for i in 0..16 {
@@ -18,7 +27,7 @@ pub fn encode_toc(property_keys: &[u16]) -> Vec<u8> {
                 if idx < property_keys.len() {
                     let backing = property_backing_type(property_keys[idx])
                         .unwrap_or_else(|| panic!("unknown property key: {}", property_keys[idx]));
-                    val |= (backing as u32) << (i * 2);
+                    val |= backing_bits(backing) << (i * 2);
                 }
             }
             writer.write_bytes(&val.to_le_bytes());

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,10 @@ fn main() {
                 eprintln!("error parsing JSON: {}", e);
                 std::process::exit(1);
             });
-            let scene = builder::build_scene(&spec);
+            let scene = builder::build_scene(&spec).unwrap_or_else(|e| {
+                eprintln!("invalid scene spec: {}", e);
+                std::process::exit(1);
+            });
             let refs: Vec<&dyn objects::core::RiveObject> = scene.iter().map(|o| &**o).collect();
             let bytes = encoder::encode_riv(&refs, file_id);
             std::fs::write(&output, &bytes).unwrap_or_else(|e| {

--- a/src/objects/animation.rs
+++ b/src/objects/animation.rs
@@ -1,4 +1,4 @@
-use crate::objects::core::{property_keys, type_keys, Property, PropertyValue, RiveObject};
+use crate::objects::core::{Property, PropertyValue, RiveObject, property_keys, type_keys};
 
 pub struct LinearAnimation {
     pub name: String,
@@ -305,12 +305,16 @@ mod tests {
             .find(|p| p.key == property_keys::LINEAR_ANIMATION_DURATION)
             .unwrap();
         assert_eq!(dur_prop.value, PropertyValue::UInt(120));
-        assert!(props
-            .iter()
-            .all(|p| p.key != property_keys::LINEAR_ANIMATION_SPEED));
-        assert!(props
-            .iter()
-            .all(|p| p.key != property_keys::LINEAR_ANIMATION_QUANTIZE));
+        assert!(
+            props
+                .iter()
+                .all(|p| p.key != property_keys::LINEAR_ANIMATION_SPEED)
+        );
+        assert!(
+            props
+                .iter()
+                .all(|p| p.key != property_keys::LINEAR_ANIMATION_QUANTIZE)
+        );
     }
 
     #[test]

--- a/src/objects/artboard.rs
+++ b/src/objects/artboard.rs
@@ -1,4 +1,4 @@
-use super::core::{property_keys, type_keys, Property, PropertyValue, RiveObject};
+use super::core::{Property, PropertyValue, RiveObject, property_keys, type_keys};
 
 pub struct Backboard;
 

--- a/src/objects/core.rs
+++ b/src/objects/core.rs
@@ -170,14 +170,87 @@ pub mod property_keys {
 
 pub fn property_backing_type(key: u16) -> Option<BackingType> {
     match key {
-        4 | 55 | 138 => Some(BackingType::String),
-        7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 20 | 21 | 31 | 33 | 34 | 35
-        | 39 | 42 | 46 | 47 | 58 | 70 | 123 | 124 | 140 | 157 | 161 | 162 | 163 | 706 | 707
-        | 781 => Some(BackingType::Float),
-        5 | 23 | 40 | 41 | 48 | 49 | 50 | 51 | 53 | 56 | 57 | 59 | 60 | 61 | 62 | 67 | 68 | 69
-        | 128 | 129 | 141 | 149 | 151 | 152 | 155 | 156 | 158 | 160 | 164 | 196 | 236 | 376
-        | 494 | 536 | 537 | 583 | 747 | 770 => Some(BackingType::UInt),
-        37 | 38 | 88 => Some(BackingType::Color),
+        property_keys::COMPONENT_NAME
+        | property_keys::ANIMATION_NAME
+        | property_keys::STATE_MACHINE_COMPONENT_NAME => Some(BackingType::String),
+
+        property_keys::LAYOUT_COMPONENT_WIDTH
+        | property_keys::LAYOUT_COMPONENT_HEIGHT
+        | property_keys::NODE_X_ARTBOARD
+        | property_keys::NODE_Y_ARTBOARD
+        | property_keys::ARTBOARD_ORIGIN_X
+        | property_keys::ARTBOARD_ORIGIN_Y
+        | property_keys::NODE_X
+        | property_keys::NODE_Y
+        | property_keys::TRANSFORM_ROTATION
+        | property_keys::TRANSFORM_SCALE_X
+        | property_keys::TRANSFORM_SCALE_Y
+        | property_keys::WORLD_TRANSFORM_OPACITY
+        | property_keys::PARAMETRIC_PATH_WIDTH
+        | property_keys::PARAMETRIC_PATH_HEIGHT
+        | property_keys::RECTANGLE_CORNER_RADIUS_TL
+        | property_keys::LINEAR_GRADIENT_START_Y
+        | property_keys::LINEAR_GRADIENT_END_X
+        | property_keys::LINEAR_GRADIENT_END_Y
+        | property_keys::GRADIENT_STOP_POSITION
+        | property_keys::LINEAR_GRADIENT_START_X
+        | property_keys::LINEAR_GRADIENT_OPACITY
+        | property_keys::STROKE_THICKNESS
+        | property_keys::LINEAR_ANIMATION_SPEED
+        | property_keys::KEY_FRAME_DOUBLE_VALUE
+        | property_keys::PARAMETRIC_PATH_ORIGIN_X
+        | property_keys::PARAMETRIC_PATH_ORIGIN_Y
+        | property_keys::STATE_MACHINE_NUMBER_VALUE
+        | property_keys::TRANSITION_NUMBER_CONDITION_VALUE
+        | property_keys::RECTANGLE_CORNER_RADIUS_TR
+        | property_keys::RECTANGLE_CORNER_RADIUS_BL
+        | property_keys::RECTANGLE_CORNER_RADIUS_BR
+        | property_keys::LAYOUT_COMPONENT_FRACTIONAL_WIDTH
+        | property_keys::LAYOUT_COMPONENT_FRACTIONAL_HEIGHT
+        | property_keys::SHAPE_LENGTH => Some(BackingType::Float),
+
+        property_keys::COMPONENT_PARENT_ID
+        | property_keys::DRAWABLE_BLEND_MODE
+        | property_keys::FILL_RULE
+        | property_keys::SHAPE_PAINT_IS_VISIBLE
+        | property_keys::STROKE_CAP
+        | property_keys::STROKE_JOIN
+        | property_keys::STROKE_TRANSFORM_AFFECTS
+        | property_keys::KEYED_OBJECT_ID
+        | property_keys::KEYED_PROPERTY_KEY
+        | property_keys::LINEAR_ANIMATION_FPS
+        | property_keys::LINEAR_ANIMATION_DURATION
+        | property_keys::LINEAR_ANIMATION_LOOP
+        | property_keys::LINEAR_ANIMATION_WORK_START
+        | property_keys::LINEAR_ANIMATION_WORK_END
+        | property_keys::LINEAR_ANIMATION_ENABLE_WORK_AREA
+        | property_keys::KEY_FRAME_FRAME
+        | property_keys::INTERPOLATING_KEY_FRAME_TYPE
+        | property_keys::INTERPOLATING_KEY_FRAME_INTERPOLATOR_ID
+        | property_keys::PATH_FLAGS
+        | property_keys::DRAWABLE_FLAGS
+        | property_keys::STATE_MACHINE_BOOL_VALUE
+        | property_keys::ANIMATION_STATE_ANIMATION_ID
+        | property_keys::STATE_TRANSITION_STATE_TO_ID
+        | property_keys::STATE_TRANSITION_FLAGS
+        | property_keys::TRANSITION_INPUT_CONDITION_INPUT_ID
+        | property_keys::TRANSITION_VALUE_CONDITION_OP
+        | property_keys::STATE_TRANSITION_DURATION
+        | property_keys::STATE_TRANSITION_EXIT_TIME
+        | property_keys::RECTANGLE_LINK_CORNER_RADIUS
+        | property_keys::LAYOUT_COMPONENT_CLIP
+        | property_keys::ARTBOARD_DEFAULT_STATE_MACHINE_ID
+        | property_keys::LINEAR_ANIMATION_QUANTIZE
+        | property_keys::LAYOUT_COMPONENT_STYLE_ID
+        | property_keys::LAYER_STATE_FLAGS
+        | property_keys::STATE_TRANSITION_RANDOM_WEIGHT
+        | property_keys::ARTBOARD_VIEW_MODEL_ID
+        | property_keys::SHAPE_PAINT_BLEND_MODE
+        | property_keys::PATH_IS_HOLE => Some(BackingType::UInt),
+
+        property_keys::SOLID_COLOR_VALUE
+        | property_keys::GRADIENT_STOP_COLOR
+        | property_keys::KEY_FRAME_COLOR_VALUE => Some(BackingType::Color),
         _ => None,
     }
 }

--- a/src/objects/shapes.rs
+++ b/src/objects/shapes.rs
@@ -1,4 +1,4 @@
-use super::core::{property_keys, type_keys, Property, PropertyValue, RiveObject};
+use super::core::{Property, PropertyValue, RiveObject, property_keys, type_keys};
 
 pub struct Node {
     pub name: String,

--- a/src/objects/state_machine.rs
+++ b/src/objects/state_machine.rs
@@ -1,4 +1,4 @@
-use super::core::{property_keys, type_keys, Property, PropertyValue, RiveObject};
+use super::core::{Property, PropertyValue, RiveObject, property_keys, type_keys};
 
 pub struct StateMachine {
     pub name: String,

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::Serialize;
 
-use crate::objects::core::{property_backing_type, BackingType};
+use crate::objects::core::{BackingType, property_backing_type};
 
 pub struct BinaryReader<'a> {
     data: &'a [u8],

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -118,6 +118,29 @@ fn test_generate_state_machine() {
 }
 
 #[test]
+fn test_generate_path() {
+    let input = fixture_path("path.json");
+    let output = temp_output("path");
+    cleanup(&output);
+
+    let result = cargo_run(&[
+        "generate",
+        input.to_str().unwrap(),
+        "-o",
+        output.to_str().unwrap(),
+    ]);
+    assert!(
+        result.status.success(),
+        "generate failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert!(output.exists());
+    let bytes = std::fs::read(&output).unwrap();
+    assert_eq!(&bytes[0..4], b"RIVE");
+    cleanup(&output);
+}
+
+#[test]
 fn test_validate_generated_file() {
     let input = fixture_path("minimal.json");
     let output = temp_output("validate_gen");

--- a/tests/fixtures/animation.json
+++ b/tests/fixtures/animation.json
@@ -1,4 +1,5 @@
 {
+  "scene_format_version": 1,
   "artboard": {
     "name": "Animated",
     "width": 500,

--- a/tests/fixtures/path.json
+++ b/tests/fixtures/path.json
@@ -1,28 +1,27 @@
 {
   "scene_format_version": 1,
   "artboard": {
-    "name": "Test",
-    "width": 500,
-    "height": 500,
+    "name": "Main",
+    "width": 400.0,
+    "height": 400.0,
     "children": [
       {
         "type": "shape",
-        "name": "MyShape",
+        "name": "shape_1",
         "children": [
           {
-            "type": "ellipse",
-            "name": "Circle",
-            "width": 100,
-            "height": 100
+            "type": "path",
+            "name": "path_1",
+            "path_flags": 1
           },
           {
             "type": "fill",
-            "name": "Fill",
+            "name": "fill_1",
             "children": [
               {
                 "type": "solid_color",
-                "name": "Red",
-                "color": "FFFF0000"
+                "name": "color_1",
+                "color": "FF00AAFF"
               }
             ]
           }

--- a/tests/fixtures/shapes.json
+++ b/tests/fixtures/shapes.json
@@ -1,4 +1,5 @@
 {
+  "scene_format_version": 1,
   "artboard": {
     "name": "Shapes",
     "width": 800,

--- a/tests/fixtures/state_machine.json
+++ b/tests/fixtures/state_machine.json
@@ -1,4 +1,5 @@
 {
+  "scene_format_version": 1,
   "artboard": {
     "name": "Interactive",
     "width": 400,

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -20,7 +20,7 @@
   </head>
   <body>
     <canvas id="canvas"></canvas>
-    <script src="https://unpkg.com/@rive-app/canvas@latest"></script>
+    <script src="https://unpkg.com/@rive-app/canvas@2.35.0"></script>
     <script>
       window.__RIVE_OK = false;
       window.__RIVE_ERROR = "";

--- a/tests/playwright/harness.html
+++ b/tests/playwright/harness.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>rive-harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        background: #f6f7f9;
+      }
+      #canvas {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <script src="https://unpkg.com/@rive-app/canvas@latest"></script>
+    <script>
+      window.__RIVE_OK = false;
+      window.__RIVE_ERROR = "";
+
+      const file = new URLSearchParams(window.location.search).get("file");
+      if (!file) {
+        window.__RIVE_ERROR = "missing file query param";
+      } else {
+        try {
+          new rive.Rive({
+            src: file,
+            canvas: document.getElementById("canvas"),
+            autoplay: true,
+            onLoad: () => {
+              window.__RIVE_OK = true;
+            },
+            onLoadError: (error) => {
+              window.__RIVE_ERROR = String(error || "rive load error");
+            },
+          });
+        } catch (error) {
+          window.__RIVE_ERROR = String(error || "rive init error");
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/tests/playwright/regression.js
+++ b/tests/playwright/regression.js
@@ -1,0 +1,84 @@
+const { chromium } = require("playwright");
+const { spawnSync, spawn } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const HARNESS_DIR = path.join(ROOT, "tests", "playwright");
+const OUT_DIR = path.join(ROOT, "target", "playwright-riv");
+const SCREENSHOT_DIR = path.join(ROOT, "target", "playwright-snapshots");
+const FIXTURES = ["minimal", "shapes", "animation", "state_machine", "path"];
+const PORT = 8765;
+
+function run(command, args, cwd = ROOT) {
+  const result = spawnSync(command, args, { cwd, stdio: "inherit" });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status}`);
+  }
+}
+
+async function main() {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+
+  for (const fixture of FIXTURES) {
+    const input = path.join(ROOT, "tests", "fixtures", `${fixture}.json`);
+    const output = path.join(OUT_DIR, `${fixture}.riv`);
+    run("cargo", ["run", "--quiet", "--", "generate", input, "-o", output]);
+    fs.copyFileSync(output, path.join(HARNESS_DIR, `${fixture}.riv`));
+  }
+
+  const server = spawn("python3", ["-m", "http.server", String(PORT), "--bind", "127.0.0.1"], {
+    cwd: HARNESS_DIR,
+    stdio: "ignore",
+  });
+
+  const browser = await chromium.launch({ headless: true });
+
+  try {
+    for (const fixture of FIXTURES) {
+      const page = await browser.newPage();
+      const runtimeErrors = [];
+      page.on("pageerror", (err) => runtimeErrors.push(String(err)));
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          runtimeErrors.push(msg.text());
+        }
+      });
+
+      await page.goto(`http://127.0.0.1:${PORT}/harness.html?file=${fixture}.riv`, {
+        waitUntil: "domcontentloaded",
+      });
+      await page.waitForTimeout(6000);
+
+      const state = await page.evaluate(() => ({
+        ok: window.__RIVE_OK,
+        error: window.__RIVE_ERROR,
+      }));
+
+      await page.screenshot({ path: path.join(SCREENSHOT_DIR, `${fixture}.png`) });
+      await page.close();
+
+      if (runtimeErrors.length > 0) {
+        throw new Error(`${fixture}.riv runtime errors: ${runtimeErrors.join(" | ")}`);
+      }
+      if (!state.ok || state.error) {
+        throw new Error(`${fixture}.riv failed to load: ${state.error || "unknown error"}`);
+      }
+    }
+  } finally {
+    await browser.close();
+    server.kill("SIGTERM");
+    for (const fixture of FIXTURES) {
+      const filePath = path.join(HARNESS_DIR, `${fixture}.riv`);
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- formalize the JSON scene contract with `scene_format_version: 1`, semantic validation errors, and a published schema at `docs/scene.schema.v1.json`
- tighten core encoding robustness by switching builder flow to `Result`, improving ToC backing bit mapping, and using property key constants for backing type mapping
- add regression coverage with a new `path` fixture/e2e test, Playwright runtime load checks (`tests/playwright/regression.js`), and screenshots under `target/playwright-snapshots`
- refresh docs/knowledge base (`README.md`, `docs/format-spec.md`, `AGENTS.md`) to reflect schema versioning and runtime verification workflow

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build`
- `npx -y -p playwright node tests/playwright/regression.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scene format versioning and Path object support; scene construction now surfaces validation errors.

* **Documentation**
  * Added detailed format specification, JSON Schema, and expanded README with versioning and testing guidance.

* **Bug Fixes & Improvements**
  * Improved validation and clearer error reporting for scenes, colors, references, and keyframes; safer runtime handling.

* **Tests**
  * Expanded fixtures, added end-to-end test and Playwright runtime regression harness and scripts.

* **CLI**
  * Enhanced command help text and input/file options for generate/validate/inspect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->