### PR TITLE
feat: inspect command filters for focused diagnostics (#16)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,19 +107,22 @@ cli/mod.rs
 
 ```bash
 cargo build
-cargo test                                    # 177 tests (159 unit + 18 e2e)
+cargo test                                    # 191 tests (164 unit + 27 e2e)
 cargo run -- generate input.json -o out.riv   # JSON → .riv
 cargo run -- validate out.riv                 # structural check
 cargo run -- inspect out.riv                  # dump object tree
 cargo run -- inspect out.riv --json           # dump as JSON
+cargo run -- inspect out.riv --type-key 1 --property-key 4
+                                              # filtered inspect (type/object/property)
 cargo clippy -- -D warnings                   # lint
 cargo fmt --check                             # format check
 ```
 
 ## TEST INFRASTRUCTURE
 
-- `cargo test` currently runs **177 tests total**: **159 unit tests** + **18 e2e tests**
+- `cargo test` currently runs **191 tests total**: **164 unit tests** + **27 e2e tests**
 - E2E coverage lives in `tests/e2e.rs` and executes CLI subprocesses for `generate`, `validate`, and `inspect`
+- `inspect` supports focused diagnostics via filters: `--type-key`, `--type-name`, `--object-index`, and `--property-key`
 - Fixtures for e2e live in `tests/fixtures/` (`minimal.json`, `shapes.json`, `animation.json`, `state_machine.json`, `path.json`, `cubic_easing.json`, `trim_path.json`, `multi_artboard.json`, `nested_artboard.json`)
 - Playwright runtime regression checks live in `tests/playwright/` and run via `npx -y -p playwright node tests/playwright/regression.js`
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -34,5 +34,29 @@ pub enum Command {
         file: PathBuf,
         #[arg(long, help = "Output parsed result as JSON")]
         json: bool,
+        #[arg(
+            long = "type-key",
+            value_name = "N",
+            help = "Filter by object type key"
+        )]
+        type_key: Vec<u16>,
+        #[arg(
+            long = "type-name",
+            value_name = "NAME",
+            help = "Filter by object type name (case-insensitive)"
+        )]
+        type_name: Vec<String>,
+        #[arg(
+            long = "object-index",
+            value_name = "N",
+            help = "Filter by global object index"
+        )]
+        object_index: Vec<usize>,
+        #[arg(
+            long = "property-key",
+            value_name = "N",
+            help = "Filter displayed properties by key"
+        )]
+        property_key: Vec<u16>,
     },
 }

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -142,7 +142,9 @@ mod tests {
     fn test_toc_only_includes_unknown_properties() {
         let artboard = Artboard::new("Test".to_string(), 500.0, 500.0);
         let data = encode_riv(&[&Backboard, &artboard], 0);
-        let parsed = crate::validator::parse_riv(&data).unwrap();
+        let parsed =
+            crate::validator::parse_riv(&data, &crate::validator::InspectFilter::default())
+                .unwrap();
         for &key in &parsed.toc_property_keys {
             assert!(
                 crate::objects::core::property_backing_type(key).is_none(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,13 +79,26 @@ fn main() {
                 }
             }
         }
-        cli::Command::Inspect { file, json } => {
+        cli::Command::Inspect {
+            file,
+            json,
+            type_key,
+            type_name,
+            object_index,
+            property_key,
+        } => {
             let bytes = std::fs::read(&file).unwrap_or_else(|e| {
                 eprintln!("error reading {:?}: {}", file, e);
                 std::process::exit(1);
             });
+            let filter = validator::InspectFilter {
+                type_keys: type_key,
+                type_names: type_name,
+                object_indices: object_index,
+                property_keys: property_key,
+            };
             if json {
-                match validator::parse_riv(&bytes) {
+                match validator::parse_riv(&bytes, &filter) {
                     Ok(parsed) => match serde_json::to_string_pretty(&parsed) {
                         Ok(json_str) => println!("{}", json_str),
                         Err(e) => {
@@ -99,7 +112,7 @@ fn main() {
                     }
                 }
             } else {
-                match validator::inspect_riv(&bytes) {
+                match validator::inspect_riv(&bytes, &filter) {
                     Ok(output) => {
                         print!("{}", output);
                     }


### PR DESCRIPTION
## Summary
- Add inspect filtering support via `InspectFilter` for `--type-key`, `--type-name` (case-insensitive), `--object-index`, and `--property-key` in both human and `--json` modes.
- Wire new inspect filter flags through clap CLI and command dispatch, including clear non-error output when filters produce no matches.
- Add e2e coverage for each filter and AND combinations, and update AGENTS.md command/docs with current test totals and filter usage.

## Verification
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo fmt --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inspect command now supports focused diagnostics with new filtering options: --type-key, --type-name, --object-index, and --property-key.

* **Tests**
  * Added 14 new tests (5 unit + 9 e2e) covering filtering capabilities.

* **Documentation**
  * Updated TEST INFRASTRUCTURE documentation to highlight filter support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->