### PR TITLE
feat: deterministic AI prompt lab harness and cookbook (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.riv
+evals/runs/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Scene specs are versioned with `scene_format_version` and currently require `1`.
 ## Cookbook
 
 - End-to-end examples are documented in `docs/cookbook.md`.
+- AI prompt templates and regression cookbook are documented in `docs/ai-prompt-cookbook.v1.md`.
 - Release maintainer flow is documented in `docs/release.md`.
 
 ## Testing

--- a/docs/ai-prompt-cookbook.v1.md
+++ b/docs/ai-prompt-cookbook.v1.md
@@ -1,0 +1,53 @@
+# AI Prompt Cookbook v1
+
+This cookbook defines known-good deterministic templates and expected output traits for prompt-lab regression runs.
+
+## Run Harness
+
+```bash
+cargo run -- ai lab \
+  --suite evals/suites/prompt_lab.v1.json \
+  --output-dir evals/runs \
+  --write-baseline evals/baselines/prompt_lab.v1.json
+```
+
+Regression check:
+
+```bash
+cargo run -- ai lab \
+  --suite evals/suites/prompt_lab.v1.json \
+  --output-dir evals/runs \
+  --baseline evals/baselines/prompt_lab.v1.json
+```
+
+## Templates and Expected Traits
+
+1. `bounce` -> `has_animation`
+2. `spinner` -> `has_animation`
+3. `pulse` -> `has_animation`
+4. `fade` -> `has_animation`
+5. `state_machine` -> `has_state_machine`
+6. `text` -> `has_text`
+7. `layout` -> `has_layout`
+8. `data_binding` -> `has_data_binding`
+9. `bones` -> `has_bones`
+10. `constraints` -> `has_constraints`
+
+## Artifact Layout
+
+- `evals/runs/<run_id>/suite.json`
+- `evals/runs/<run_id>/report.json`
+- `evals/runs/<run_id>/samples/<case_id>/input.txt`
+- `evals/runs/<run_id>/samples/<case_id>/scene.json`
+- `evals/runs/<run_id>/samples/<case_id>/output.riv`
+- `evals/runs/<run_id>/samples/<case_id>/validate.json`
+- `evals/runs/<run_id>/samples/<case_id>/inspect.json`
+
+## Multimodal Hooks
+
+Suite cases support optional fields:
+
+- `text_hint`
+- `image_path`
+
+These fields are persisted into run reports for future image/text-informed prompt variants.

--- a/evals/suites/prompt_lab.v1.json
+++ b/evals/suites/prompt_lab.v1.json
@@ -1,0 +1,66 @@
+{
+  "suite_name": "prompt-lab-v1",
+  "suite_version": 1,
+  "cases": [
+    {
+      "id": "bounce",
+      "input_kind": "template",
+      "input": "bounce",
+      "expected_traits": ["has_animation"]
+    },
+    {
+      "id": "spinner",
+      "input_kind": "template",
+      "input": "spinner",
+      "expected_traits": ["has_animation"]
+    },
+    {
+      "id": "pulse",
+      "input_kind": "template",
+      "input": "pulse",
+      "expected_traits": ["has_animation"]
+    },
+    {
+      "id": "fade",
+      "input_kind": "template",
+      "input": "fade",
+      "expected_traits": ["has_animation"]
+    },
+    {
+      "id": "state-machine",
+      "input_kind": "template",
+      "input": "state_machine",
+      "expected_traits": ["has_state_machine"]
+    },
+    {
+      "id": "text",
+      "input_kind": "template",
+      "input": "text",
+      "expected_traits": ["has_text"]
+    },
+    {
+      "id": "layout",
+      "input_kind": "template",
+      "input": "layout",
+      "expected_traits": ["has_layout"]
+    },
+    {
+      "id": "data-binding",
+      "input_kind": "template",
+      "input": "data_binding",
+      "expected_traits": ["has_data_binding"]
+    },
+    {
+      "id": "bones",
+      "input_kind": "template",
+      "input": "bones",
+      "expected_traits": ["has_bones"]
+    },
+    {
+      "id": "constraints",
+      "input_kind": "template",
+      "input": "constraints",
+      "expected_traits": ["has_constraints"]
+    }
+  ]
+}

--- a/src/ai/eval.rs
+++ b/src/ai/eval.rs
@@ -1,0 +1,479 @@
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::ai::{AiConfig, AiError, RepairEngine, create_provider};
+use crate::validator::{InspectFilter, ValidationReport, parse_riv, validate_riv};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvalSuite {
+    pub suite_name: String,
+    pub suite_version: u32,
+    pub cases: Vec<EvalCase>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvalCase {
+    pub id: String,
+    pub input_kind: InputKind,
+    pub input: String,
+    #[serde(default)]
+    pub expected_traits: Vec<String>,
+    #[serde(default)]
+    pub text_hint: Option<String>,
+    #[serde(default)]
+    pub image_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InputKind {
+    Template,
+    Prompt,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvalBaseline {
+    pub suite_name: String,
+    pub suite_version: u32,
+    pub case_hashes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EvalReport {
+    pub run_id: String,
+    pub suite_name: String,
+    pub suite_version: u32,
+    pub output_dir: String,
+    pub case_count: usize,
+    pub valid_count: usize,
+    pub validity_rate: f64,
+    pub average_retries: f64,
+    pub style_adherence_rate: f64,
+    pub reproducibility_rate: f64,
+    pub drift_count: usize,
+    pub cases: Vec<EvalCaseReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EvalCaseReport {
+    pub id: String,
+    pub input_kind: String,
+    pub input: String,
+    pub expected_traits: Vec<String>,
+    pub style_matched_traits: Vec<String>,
+    pub style_score: f64,
+    pub valid: bool,
+    pub retries: u8,
+    pub reproducible: bool,
+    pub output_hash: Option<String>,
+    pub drifted: bool,
+    pub failure_reason: Option<String>,
+    pub artifact_dir: String,
+    pub text_hint: Option<String>,
+    pub image_path: Option<String>,
+}
+
+fn run_id() -> Result<String, String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("system time error: {}", e))?;
+    Ok(format!("{}", now.as_secs()))
+}
+
+fn hash_bytes(bytes: &[u8]) -> String {
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn write_json<P: AsRef<Path>, T: Serialize>(path: P, value: &T) -> Result<(), String> {
+    let pretty = serde_json::to_string_pretty(value).map_err(|e| {
+        format!(
+            "failed to serialize JSON for {}: {}",
+            path.as_ref().display(),
+            e
+        )
+    })?;
+    fs::write(path.as_ref(), pretty)
+        .map_err(|e| format!("failed to write {}: {}", path.as_ref().display(), e))
+}
+
+fn collect_object_types(value: &Value, out: &mut HashSet<String>) {
+    if let Some(obj) = value.as_object() {
+        if let Some(t) = obj.get("type").and_then(Value::as_str) {
+            out.insert(t.to_string());
+        }
+        for child in obj.values() {
+            collect_object_types(child, out);
+        }
+    }
+    if let Some(arr) = value.as_array() {
+        for child in arr {
+            collect_object_types(child, out);
+        }
+    }
+}
+
+fn has_animations(scene: &Value) -> bool {
+    if let Some(artboard) = scene.get("artboard")
+        && artboard
+            .get("animations")
+            .and_then(Value::as_array)
+            .is_some_and(|a| !a.is_empty())
+    {
+        return true;
+    }
+    scene
+        .get("artboards")
+        .and_then(Value::as_array)
+        .is_some_and(|boards| {
+            boards.iter().any(|b| {
+                b.get("animations")
+                    .and_then(Value::as_array)
+                    .is_some_and(|a| !a.is_empty())
+            })
+        })
+}
+
+fn has_state_machines(scene: &Value) -> bool {
+    if let Some(artboard) = scene.get("artboard")
+        && artboard
+            .get("state_machines")
+            .and_then(Value::as_array)
+            .is_some_and(|a| !a.is_empty())
+    {
+        return true;
+    }
+    scene
+        .get("artboards")
+        .and_then(Value::as_array)
+        .is_some_and(|boards| {
+            boards.iter().any(|b| {
+                b.get("state_machines")
+                    .and_then(Value::as_array)
+                    .is_some_and(|a| !a.is_empty())
+            })
+        })
+}
+
+fn case_traits(scene: &Value) -> HashSet<String> {
+    let mut object_types = HashSet::new();
+    collect_object_types(scene, &mut object_types);
+
+    let mut traits = HashSet::new();
+    if has_animations(scene) {
+        traits.insert("has_animation".to_string());
+    }
+    if has_state_machines(scene) {
+        traits.insert("has_state_machine".to_string());
+    }
+    if scene
+        .get("artboards")
+        .and_then(Value::as_array)
+        .is_some_and(|a| a.len() > 1)
+    {
+        traits.insert("multi_artboard".to_string());
+    }
+
+    let type_to_trait = [
+        ("text", "has_text"),
+        ("text_style", "has_text"),
+        ("text_value_run", "has_text"),
+        ("layout_component", "has_layout"),
+        ("layout_component_style", "has_layout"),
+        ("view_model", "has_data_binding"),
+        ("view_model_property", "has_data_binding"),
+        ("data_bind", "has_data_binding"),
+        ("image_asset", "has_assets"),
+        ("font_asset", "has_assets"),
+        ("audio_asset", "has_assets"),
+        ("file_asset_contents", "has_assets"),
+        ("bone", "has_bones"),
+        ("root_bone", "has_bones"),
+        ("skin", "has_bones"),
+        ("tendon", "has_bones"),
+        ("weight", "has_bones"),
+        ("cubic_weight", "has_bones"),
+        ("ik_constraint", "has_constraints"),
+        ("distance_constraint", "has_constraints"),
+        ("transform_constraint", "has_constraints"),
+        ("translation_constraint", "has_constraints"),
+        ("scale_constraint", "has_constraints"),
+        ("rotation_constraint", "has_constraints"),
+        ("linear_gradient", "has_gradients"),
+        ("radial_gradient", "has_gradients"),
+        ("trim_path", "has_trim_path"),
+    ];
+
+    for (t, tag) in type_to_trait {
+        if object_types.contains(t) {
+            traits.insert(tag.to_string());
+        }
+    }
+    traits
+}
+
+fn style_score(scene: &Value, expected_traits: &[String]) -> (f64, Vec<String>) {
+    if expected_traits.is_empty() {
+        return (1.0, Vec::new());
+    }
+    let traits = case_traits(scene);
+    let matched: Vec<String> = expected_traits
+        .iter()
+        .filter(|t| traits.contains(t.as_str()))
+        .cloned()
+        .collect();
+    (matched.len() as f64 / expected_traits.len() as f64, matched)
+}
+
+fn run_case(
+    case: &EvalCase,
+    case_dir: &Path,
+    file_id: u64,
+    max_retries: u8,
+    baseline_hash: Option<&String>,
+) -> Result<EvalCaseReport, String> {
+    fs::create_dir_all(case_dir)
+        .map_err(|e| format!("failed to create {}: {}", case_dir.display(), e))?;
+
+    let provider_input = &case.input;
+    fs::write(case_dir.join("input.txt"), provider_input)
+        .map_err(|e| format!("failed to write input.txt: {}", e))?;
+
+    let config = AiConfig::resolve(None, Some("template".to_string()))
+        .map_err(|e| format!("AI config error: {}", e))?;
+    let provider = create_provider(&config, matches!(case.input_kind, InputKind::Template))
+        .map_err(|e| format!("AI provider error: {}", e))?;
+
+    let scene_json = provider
+        .generate(provider_input, &config)
+        .map_err(|e| format!("generation failed: {}", e))?;
+    write_json(case_dir.join("scene.json"), &scene_json)?;
+
+    let engine = RepairEngine::new(max_retries);
+    let repaired = engine
+        .repair(scene_json.clone(), file_id)
+        .map_err(|e| match e {
+            AiError::RepairFailed {
+                attempts,
+                final_error,
+            } => format!(
+                "repair failed after {} attempts: {}",
+                attempts.len(),
+                final_error
+            ),
+            other => format!("repair failed: {}", other),
+        })?;
+
+    fs::write(case_dir.join("output.riv"), &repaired.riv_bytes)
+        .map_err(|e| format!("failed to write output.riv: {}", e))?;
+
+    let validation: ValidationReport =
+        validate_riv(&repaired.riv_bytes).map_err(|e| format!("validate failed: {}", e))?;
+    write_json(case_dir.join("validate.json"), &validation)?;
+
+    let parsed = parse_riv(&repaired.riv_bytes, &InspectFilter::default())
+        .map_err(|e| format!("inspect parse failed: {}", e))?;
+    write_json(case_dir.join("inspect.json"), &parsed)?;
+
+    let repeat = engine
+        .repair(scene_json.clone(), file_id)
+        .map_err(|e| format!("repro check repair failed: {}", e))?;
+    let reproducible = repaired.riv_bytes == repeat.riv_bytes;
+
+    let output_hash = hash_bytes(&repaired.riv_bytes);
+    let (style_score_value, matched_traits) = style_score(&scene_json, &case.expected_traits);
+
+    let drifted = baseline_hash.is_some_and(|h| h != &output_hash);
+
+    Ok(EvalCaseReport {
+        id: case.id.clone(),
+        input_kind: match case.input_kind {
+            InputKind::Template => "template".to_string(),
+            InputKind::Prompt => "prompt".to_string(),
+        },
+        input: case.input.clone(),
+        expected_traits: case.expected_traits.clone(),
+        style_matched_traits: matched_traits,
+        style_score: style_score_value,
+        valid: validation.valid,
+        retries: repaired.total_retries,
+        reproducible,
+        output_hash: Some(output_hash),
+        drifted,
+        failure_reason: if validation.valid {
+            None
+        } else {
+            Some(validation.errors.join("; "))
+        },
+        artifact_dir: case_dir.display().to_string(),
+        text_hint: case.text_hint.clone(),
+        image_path: case.image_path.clone(),
+    })
+}
+
+pub fn run_eval_suite(
+    suite_path: &Path,
+    output_root: &Path,
+    file_id: u64,
+    max_retries: u8,
+    baseline_path: Option<&Path>,
+    write_baseline_path: Option<&Path>,
+) -> Result<EvalReport, String> {
+    let suite_str = fs::read_to_string(suite_path)
+        .map_err(|e| format!("failed to read suite {}: {}", suite_path.display(), e))?;
+    let suite: EvalSuite = serde_json::from_str(&suite_str)
+        .map_err(|e| format!("failed to parse suite {}: {}", suite_path.display(), e))?;
+
+    let baseline: Option<EvalBaseline> = if let Some(path) = baseline_path {
+        let contents = fs::read_to_string(path)
+            .map_err(|e| format!("failed to read baseline {}: {}", path.display(), e))?;
+        Some(
+            serde_json::from_str(&contents)
+                .map_err(|e| format!("failed to parse baseline {}: {}", path.display(), e))?,
+        )
+    } else {
+        None
+    };
+
+    let run_id = run_id()?;
+    let run_dir = output_root.join(&run_id);
+    let samples_dir = run_dir.join("samples");
+    fs::create_dir_all(&samples_dir)
+        .map_err(|e| format!("failed to create {}: {}", samples_dir.display(), e))?;
+
+    write_json(run_dir.join("suite.json"), &suite)?;
+
+    let mut cases: Vec<EvalCaseReport> = Vec::new();
+    for case in &suite.cases {
+        let case_dir = samples_dir.join(&case.id);
+        let baseline_hash = baseline.as_ref().and_then(|b| b.case_hashes.get(&case.id));
+
+        let result = run_case(case, &case_dir, file_id, max_retries, baseline_hash);
+        match result {
+            Ok(r) => cases.push(r),
+            Err(err) => {
+                let id = case.id.clone();
+                cases.push(EvalCaseReport {
+                    id,
+                    input_kind: match case.input_kind {
+                        InputKind::Template => "template".to_string(),
+                        InputKind::Prompt => "prompt".to_string(),
+                    },
+                    input: case.input.clone(),
+                    expected_traits: case.expected_traits.clone(),
+                    style_matched_traits: Vec::new(),
+                    style_score: 0.0,
+                    valid: false,
+                    retries: 0,
+                    reproducible: false,
+                    output_hash: None,
+                    drifted: false,
+                    failure_reason: Some(err),
+                    artifact_dir: case_dir.display().to_string(),
+                    text_hint: case.text_hint.clone(),
+                    image_path: case.image_path.clone(),
+                });
+            }
+        }
+    }
+
+    let valid_count = cases.iter().filter(|c| c.valid).count();
+    let validity_rate = if cases.is_empty() {
+        0.0
+    } else {
+        valid_count as f64 / cases.len() as f64
+    };
+
+    let average_retries = if cases.is_empty() {
+        0.0
+    } else {
+        cases.iter().map(|c| c.retries as f64).sum::<f64>() / cases.len() as f64
+    };
+
+    let style_adherence_rate = if cases.is_empty() {
+        0.0
+    } else {
+        cases.iter().map(|c| c.style_score).sum::<f64>() / cases.len() as f64
+    };
+
+    let reproducibility_rate = if cases.is_empty() {
+        0.0
+    } else {
+        cases.iter().filter(|c| c.reproducible).count() as f64 / cases.len() as f64
+    };
+
+    let drift_count = cases.iter().filter(|c| c.drifted).count();
+
+    let report = EvalReport {
+        run_id: run_id.clone(),
+        suite_name: suite.suite_name.clone(),
+        suite_version: suite.suite_version,
+        output_dir: run_dir.display().to_string(),
+        case_count: cases.len(),
+        valid_count,
+        validity_rate,
+        average_retries,
+        style_adherence_rate,
+        reproducibility_rate,
+        drift_count,
+        cases,
+    };
+
+    write_json(run_dir.join("report.json"), &report)?;
+
+    if let Some(path) = write_baseline_path {
+        let mut case_hashes = BTreeMap::new();
+        for case in &report.cases {
+            if let Some(hash) = &case.output_hash {
+                case_hashes.insert(case.id.clone(), hash.clone());
+            }
+        }
+        let baseline = EvalBaseline {
+            suite_name: suite.suite_name,
+            suite_version: suite.suite_version,
+            case_hashes,
+        };
+        write_json(path, &baseline)?;
+    }
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_style_score_empty_expectations() {
+        let scene = serde_json::json!({"scene_format_version":1});
+        let (score, matched) = style_score(&scene, &[]);
+        assert_eq!(score, 1.0);
+        assert!(matched.is_empty());
+    }
+
+    #[test]
+    fn test_style_score_matches_animation_trait() {
+        let scene = serde_json::json!({
+            "scene_format_version": 1,
+            "artboard": {
+                "name": "A",
+                "width": 100,
+                "height": 100,
+                "children": [],
+                "animations": [{"name": "anim", "fps": 60, "duration": 10, "keyframes": []}]
+            }
+        });
+        let expected = vec!["has_animation".to_string(), "has_state_machine".to_string()];
+        let (score, matched) = style_score(&scene, &expected);
+        assert!(score > 0.4 && score < 0.6);
+        assert_eq!(matched, vec!["has_animation".to_string()]);
+    }
+}

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod error;
+pub mod eval;
 pub mod provider;
 pub mod repair;
 pub mod templates;
 pub use config::AiConfig;
 pub use error::AiError;
+pub use eval::run_eval_suite;
 pub use provider::{AiProvider, create_provider};
 pub use repair::{RepairEngine, RepairResult, format_repair_summary, remediation_hints};

--- a/src/ai/templates.rs
+++ b/src/ai/templates.rs
@@ -254,19 +254,85 @@ const FADE_TEMPLATE: &str = r#"
 }
 "#;
 
+const MINIMAL_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/minimal.json"
+));
+const SHAPES_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/shapes.json"
+));
+const ANIMATION_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/animation.json"
+));
+const STATE_MACHINE_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/state_machine.json"
+));
+const GRADIENTS_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/gradients.json"
+));
+const TEXT_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/text.json"
+));
+const LAYOUT_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/layout.json"
+));
+const DATA_BINDING_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/data_binding.json"
+));
+const BONES_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/bones.json"
+));
+const CONSTRAINTS_TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/constraints.json"
+));
+
 pub fn get_template(name: &str) -> Result<serde_json::Value, AiError> {
     let json_str = match name {
         "bounce" => BOUNCE_TEMPLATE,
         "spinner" => SPINNER_TEMPLATE,
         "pulse" => PULSE_TEMPLATE,
         "fade" => FADE_TEMPLATE,
+        "minimal" => MINIMAL_TEMPLATE,
+        "shapes" => SHAPES_TEMPLATE,
+        "animation" => ANIMATION_TEMPLATE,
+        "state_machine" => STATE_MACHINE_TEMPLATE,
+        "gradients" => GRADIENTS_TEMPLATE,
+        "text" => TEXT_TEMPLATE,
+        "layout" => LAYOUT_TEMPLATE,
+        "data_binding" => DATA_BINDING_TEMPLATE,
+        "bones" => BONES_TEMPLATE,
+        "constraints" => CONSTRAINTS_TEMPLATE,
         _ => return Err(AiError::UnknownTemplate(name.to_string())),
     };
     serde_json::from_str(json_str).map_err(|e| AiError::InvalidResponse(e.to_string()))
 }
 
 pub fn list_templates() -> &'static [&'static str] {
-    &["bounce", "spinner", "pulse", "fade"]
+    &[
+        "bounce",
+        "spinner",
+        "pulse",
+        "fade",
+        "minimal",
+        "shapes",
+        "animation",
+        "state_machine",
+        "gradients",
+        "text",
+        "layout",
+        "data_binding",
+        "bones",
+        "constraints",
+    ]
 }
 
 #[cfg(test)]
@@ -291,5 +357,10 @@ mod tests {
     #[test]
     fn test_unknown_template() {
         assert!(get_template("nonexistent").is_err());
+    }
+
+    #[test]
+    fn test_template_catalog_has_minimum_size() {
+        assert!(list_templates().len() >= 10);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -89,4 +89,26 @@ pub enum AiCommand {
         )]
         max_retries: u8,
     },
+    Lab {
+        #[arg(long, help = "Path to eval suite JSON file")]
+        suite: PathBuf,
+        #[arg(
+            long,
+            default_value = "evals/runs",
+            help = "Output directory for eval runs"
+        )]
+        output_dir: PathBuf,
+        #[arg(long, default_value = "0", help = "Rive file id")]
+        file_id: u64,
+        #[arg(
+            long,
+            default_value = "3",
+            help = "Max auto-repair retries (0 = no repair)"
+        )]
+        max_retries: u8,
+        #[arg(long, help = "Optional baseline JSON file for drift detection")]
+        baseline: Option<PathBuf>,
+        #[arg(long, help = "Write baseline JSON from this run")]
+        write_baseline: Option<PathBuf>,
+    },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,47 @@ fn main() {
                     }
                 }
             }
+            cli::AiCommand::Lab {
+                suite,
+                output_dir,
+                file_id,
+                max_retries,
+                baseline,
+                write_baseline,
+            } => {
+                match ai::run_eval_suite(
+                    &suite,
+                    &output_dir,
+                    file_id,
+                    max_retries,
+                    baseline.as_deref(),
+                    write_baseline.as_deref(),
+                ) {
+                    Ok(report) => {
+                        println!("run_id={}", report.run_id);
+                        println!("output_dir={}", report.output_dir);
+                        println!(
+                            "validity_rate={:.3} ({}/{})",
+                            report.validity_rate, report.valid_count, report.case_count
+                        );
+                        println!("average_retries={:.3}", report.average_retries);
+                        println!("style_adherence_rate={:.3}", report.style_adherence_rate);
+                        println!("reproducibility_rate={:.3}", report.reproducibility_rate);
+                        println!("drift_count={}", report.drift_count);
+                        if report.drift_count > 0 {
+                            eprintln!(
+                                "regression drift detected in {} case(s)",
+                                report.drift_count
+                            );
+                            std::process::exit(1);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("ai lab failed: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            }
         },
     }
 }


### PR DESCRIPTION
## Summary
- add `ai lab` evaluation harness with batch suite execution, artifact capture (`scene.json`, `.riv`, `validate.json`, `inspect.json`), scoring (validity, retries, style adherence, reproducibility), optional baseline drift detection, and baseline writing
- expand deterministic template catalog to 10+ tested templates and add a versioned suite config at `evals/suites/prompt_lab.v1.json`
- add AI prompt cookbook v1 docs and e2e coverage for harness artifact output and regression drift failure behavior

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo run -- ai lab --suite evals/suites/prompt_lab.v1.json --output-dir evals/runs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ai lab` command for running evaluation suites with regression detection and reporting
  * Introduced 11 new template types for AI scene generation (bounce, spinner, pulse, fade, state_machine, text, layout, data_binding, bones, constraints)

* **Documentation**
  * Added AI prompt cookbook documentation covering template management, evaluation framework, and regression testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->