### PR TITLE
feat: add image drawable support and asset reference checks (#37)

### DIFF
--- a/docs/scene.schema.v1.json
+++ b/docs/scene.schema.v1.json
@@ -75,6 +75,7 @@
         { "$ref": "#/$defs/radial_gradient" },
         { "$ref": "#/$defs/gradient_stop" },
         { "$ref": "#/$defs/node" },
+        { "$ref": "#/$defs/image" },
         { "$ref": "#/$defs/path" },
         { "$ref": "#/$defs/trim_path" },
         { "$ref": "#/$defs/nested_artboard" }
@@ -237,6 +238,23 @@
           "type": "object",
           "properties": {
             "type": { "const": "node" },
+            "x": { "type": "number" },
+            "y": { "type": "number" }
+          },
+          "unevaluatedProperties": false
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "image": {
+      "allOf": [
+        { "$ref": "#/$defs/base_object" },
+        {
+          "type": "object",
+          "required": ["asset_id"],
+          "properties": {
+            "type": { "const": "image" },
+            "asset_id": { "type": "integer", "minimum": 0 },
             "x": { "type": "number" },
             "y": { "type": "number" }
           },

--- a/src/objects/core.rs
+++ b/src/objects/core.rs
@@ -103,6 +103,7 @@ pub mod type_keys {
     pub const TRANSFORM_SPACE_CONSTRAINT: u16 = 90;
     pub const WORLD_TRANSFORM_COMPONENT: u16 = 91;
     pub const NESTED_ARTBOARD: u16 = 92;
+    pub const IMAGE: u16 = 100;
     pub const CUBIC_VALUE_INTERPOLATOR: u16 = 138;
     pub const CUBIC_INTERPOLATOR: u16 = 139;
     pub const INTERPOLATING_KEY_FRAME: u16 = 170;
@@ -261,6 +262,7 @@ pub mod property_keys {
     pub const TRANSFORM_CONSTRAINT_ORIGIN_Y: u16 = 373;
     pub const ASSET_NAME: u16 = 203;
     pub const FILE_ASSET_ASSET_ID: u16 = 204;
+    pub const IMAGE_ASSET_ID: u16 = 206;
     pub const FILE_ASSET_CDN_BASE_URL: u16 = 362;
     pub const FILE_ASSET_CONTENTS_BYTES: u16 = 212;
     pub const TEXT_ALIGN_VALUE: u16 = 281;
@@ -518,6 +520,7 @@ pub fn property_backing_type(key: u16) -> Option<BackingType> {
         | property_keys::TEXT_STYLE_FONT_ASSET_ID
         | property_keys::TEXT_VALUE_RUN_STYLE_ID
         | property_keys::FILE_ASSET_ASSET_ID
+        | property_keys::IMAGE_ASSET_ID
         | property_keys::FILE_ASSET_CONTENTS_BYTES
         | property_keys::LAYOUT_STYLE_FLEX_DIRECTION
         | property_keys::LAYOUT_STYLE_FLEX_WRAP
@@ -627,6 +630,10 @@ mod tests {
             property_backing_type(property_keys::PATH_IS_HOLE),
             Some(BackingType::UInt)
         );
+        assert_eq!(
+            property_backing_type(property_keys::IMAGE_ASSET_ID),
+            Some(BackingType::UInt)
+        );
     }
 
     #[test]
@@ -725,6 +732,7 @@ mod tests {
         assert_eq!(type_keys::TRIM_PATH, 47);
         assert_eq!(type_keys::WORLD_TRANSFORM_COMPONENT, 91);
         assert_eq!(type_keys::NESTED_ARTBOARD, 92);
+        assert_eq!(type_keys::IMAGE, 100);
         assert_eq!(type_keys::CUBIC_VALUE_INTERPOLATOR, 138);
         assert_eq!(type_keys::CUBIC_INTERPOLATOR, 139);
         assert_eq!(type_keys::INTERPOLATING_KEY_FRAME, 170);

--- a/src/objects/shapes.rs
+++ b/src/objects/shapes.rs
@@ -695,6 +695,62 @@ impl RiveObject for Drawable {
     }
 }
 
+pub struct Image {
+    pub name: String,
+    pub parent_id: u64,
+    pub asset_id: u64,
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Image {
+    pub fn new(name: String, parent_id: u64, asset_id: u64) -> Self {
+        Image {
+            name,
+            parent_id,
+            asset_id,
+            x: 0.0,
+            y: 0.0,
+        }
+    }
+}
+
+impl RiveObject for Image {
+    fn type_key(&self) -> u16 {
+        type_keys::IMAGE
+    }
+
+    fn properties(&self) -> Vec<Property> {
+        let mut props = vec![
+            Property {
+                key: property_keys::COMPONENT_NAME,
+                value: PropertyValue::String(self.name.clone()),
+            },
+            Property {
+                key: property_keys::COMPONENT_PARENT_ID,
+                value: PropertyValue::UInt(self.parent_id),
+            },
+            Property {
+                key: property_keys::IMAGE_ASSET_ID,
+                value: PropertyValue::UInt(self.asset_id),
+            },
+        ];
+        if self.x != 0.0 {
+            props.push(Property {
+                key: property_keys::NODE_X,
+                value: PropertyValue::Float(self.x),
+            });
+        }
+        if self.y != 0.0 {
+            props.push(Property {
+                key: property_keys::NODE_Y,
+                value: PropertyValue::Float(self.y),
+            });
+        }
+        props
+    }
+}
+
 pub struct ShapePaint {
     pub name: String,
     pub parent_id: u64,
@@ -1154,6 +1210,36 @@ mod tests {
             drawable_flags: 0,
         };
         assert_eq!(d.type_key(), 13);
+    }
+
+    #[test]
+    fn test_image_type_key() {
+        let image = Image::new("Img".to_string(), 1, 0);
+        assert_eq!(image.type_key(), 100);
+    }
+
+    #[test]
+    fn test_image_default_properties() {
+        let image = Image::new("Img".to_string(), 2, 0);
+        let props = image.properties();
+        assert_eq!(props.len(), 3);
+        assert_eq!(props[0].key, property_keys::COMPONENT_NAME);
+        assert_eq!(props[1].key, property_keys::COMPONENT_PARENT_ID);
+        assert_eq!(props[2].key, property_keys::IMAGE_ASSET_ID);
+        assert_eq!(props[2].value, PropertyValue::UInt(0));
+    }
+
+    #[test]
+    fn test_image_with_position() {
+        let mut image = Image::new("Img".to_string(), 2, 1);
+        image.x = 12.0;
+        image.y = 24.0;
+        let props = image.properties();
+        assert_eq!(props.len(), 5);
+        assert_eq!(props[3].key, property_keys::NODE_X);
+        assert_eq!(props[3].value, PropertyValue::Float(12.0));
+        assert_eq!(props[4].key, property_keys::NODE_Y);
+        assert_eq!(props[4].value, PropertyValue::Float(24.0));
     }
 
     #[test]

--- a/tests/fixtures/image_node.json
+++ b/tests/fixtures/image_node.json
@@ -1,0 +1,23 @@
+{
+  "scene_format_version": 1,
+  "artboard": {
+    "name": "ImageNodeDemo",
+    "width": 500,
+    "height": 500,
+    "children": [
+      {
+        "type": "image_asset",
+        "name": "HeroImage",
+        "asset_id": 100,
+        "cdn_base_url": "https://cdn.example.com/images"
+      },
+      {
+        "type": "image",
+        "name": "HeroSprite",
+        "asset_id": 0,
+        "x": 32,
+        "y": 48
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `Image` drawable support (`type_key 100`, `property_key 206`) in objects/core/shapes and wire SceneSpec parsing (`type: \"image\"`) in builder
- add strict image-asset reference checks (builder-time + validator-time) so image nodes must reference a previously defined `image_asset` index
- extend schema + fixtures/tests with `tests/fixtures/image_node.json` and new unit/e2e coverage for generate/validate/inspect paths

## Verification
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image objects can now be added to scenes with support for asset references and optional x/y positioning
  * Validation ensures images reference previously defined image assets in the correct order

<!-- end of auto-generated comment: release notes by coderabbit.ai -->