### PR TITLE
fix: HiDPI canvas rendering for crisp animations

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -541,9 +541,18 @@
             return options;
         }
 
+        function resizeCanvasForHiDPI(canvas) {
+            if (!canvas) return;
+            const rect = canvas.getBoundingClientRect();
+            const dpr = window.devicePixelRatio || 1;
+            canvas.width = Math.round(rect.width * dpr);
+            canvas.height = Math.round(rect.height * dpr);
+        }
+
         function createRiveInstance(fixture, isReplay = false) {
             const name = fixture.name;
             const canvas = document.getElementById(`canvas-${name}`);
+            resizeCanvasForHiDPI(canvas);
             const statusEl = document.getElementById(`status-${name}`);
             const errorEl = document.getElementById(`error-${name}`);
             const options = runtimeOptions(name);
@@ -584,6 +593,7 @@
 
             if (fixture.hasReference) {
                 const refCanvas = document.getElementById(`canvas-${name}-ref`);
+                resizeCanvasForHiDPI(refCanvas);
                 riveRefInstances[name] = new rive.Rive({
                     src: fixture.referenceSource,
                     canvas: refCanvas,


### PR DESCRIPTION
## Summary

- Set canvas backing resolution to display size × `devicePixelRatio` before Rive init
- All canvases (generated + reference) now render at native pixel density
- Previously, canvases defaulted to 300×150 backing pixels and CSS-stretched to fill, causing blurry rendering on Retina/HiDPI displays

## Changes

- Added `resizeCanvasForHiDPI()` function that sets `canvas.width`/`canvas.height` to `rect.width × dpr`/`rect.height × dpr`
- Called before every `new rive.Rive()` instantiation (both generated and reference canvases)