### PR TITLE
feat: add Solo, KeyFrameId, StateMachineListener, ListenerBoolChange, NestedStateMachine

### DIFF
--- a/src/objects/animation.rs
+++ b/src/objects/animation.rs
@@ -185,6 +185,51 @@ impl KeyFrameColor {
     }
 }
 
+pub struct KeyFrameId {
+    pub frame: u64,
+    pub interpolation_type: u64,
+    pub interpolator_id: u64,
+    pub value: u64,
+}
+
+impl KeyFrameId {
+    pub fn new(frame: u64, value: u64) -> Self {
+        Self {
+            frame,
+            interpolation_type: 1,
+            interpolator_id: u32::MAX as u64,
+            value,
+        }
+    }
+}
+
+impl RiveObject for KeyFrameId {
+    fn type_key(&self) -> u16 {
+        type_keys::KEY_FRAME_ID
+    }
+
+    fn properties(&self) -> Vec<Property> {
+        vec![
+            Property {
+                key: property_keys::KEY_FRAME_FRAME,
+                value: PropertyValue::UInt(self.frame),
+            },
+            Property {
+                key: property_keys::INTERPOLATING_KEY_FRAME_TYPE,
+                value: PropertyValue::UInt(self.interpolation_type),
+            },
+            Property {
+                key: property_keys::INTERPOLATING_KEY_FRAME_INTERPOLATOR_ID,
+                value: PropertyValue::UInt(self.interpolator_id),
+            },
+            Property {
+                key: property_keys::KEY_FRAME_ID_VALUE,
+                value: PropertyValue::UInt(self.value),
+            },
+        ]
+    }
+}
+
 impl RiveObject for KeyFrameColor {
     fn type_key(&self) -> u16 {
         type_keys::KEY_FRAME_COLOR
@@ -460,6 +505,30 @@ mod tests {
     }
 
     #[test]
+    fn test_key_frame_id_type_key() {
+        let kf = KeyFrameId::new(12, 42);
+        assert_eq!(kf.type_key(), type_keys::KEY_FRAME_ID);
+    }
+
+    #[test]
+    fn test_key_frame_id_properties() {
+        let kf = KeyFrameId::new(12, 42);
+        let props = kf.properties();
+        assert_eq!(props.len(), 4);
+        assert_eq!(props[0].key, property_keys::KEY_FRAME_FRAME);
+        assert_eq!(props[0].value, PropertyValue::UInt(12));
+        assert_eq!(props[1].key, property_keys::INTERPOLATING_KEY_FRAME_TYPE);
+        assert_eq!(props[1].value, PropertyValue::UInt(1));
+        assert_eq!(
+            props[2].key,
+            property_keys::INTERPOLATING_KEY_FRAME_INTERPOLATOR_ID
+        );
+        assert_eq!(props[2].value, PropertyValue::UInt(u32::MAX as u64));
+        assert_eq!(props[3].key, property_keys::KEY_FRAME_ID_VALUE);
+        assert_eq!(props[3].value, PropertyValue::UInt(42));
+    }
+
+    #[test]
     fn test_cubic_ease_interpolator_type_key() {
         let interp = CubicEaseInterpolator::new(0.42, 0.0, 0.58, 1.0);
         assert_eq!(interp.type_key(), type_keys::CUBIC_EASE_INTERPOLATOR);
@@ -527,6 +596,12 @@ mod tests {
     #[test]
     fn test_key_frame_color_default_interpolator_sentinel() {
         let kf = KeyFrameColor::new(0, 0);
+        assert_eq!(kf.interpolator_id, u32::MAX as u64);
+    }
+
+    #[test]
+    fn test_key_frame_id_default_interpolator_sentinel() {
+        let kf = KeyFrameId::new(0, 0);
         assert_eq!(kf.interpolator_id, u32::MAX as u64);
     }
 }

--- a/src/objects/core.rs
+++ b/src/objects/core.rs
@@ -69,6 +69,7 @@ pub mod type_keys {
     pub const KEY_FRAME_COLOR: u16 = 37;
     pub const TRANSFORM_COMPONENT: u16 = 38;
     pub const TRIM_PATH: u16 = 47;
+    pub const KEY_FRAME_ID: u16 = 50;
     pub const STATE_MACHINE: u16 = 53;
     pub const STATE_MACHINE_COMPONENT: u16 = 54;
     pub const STATE_MACHINE_INPUT: u16 = 55;
@@ -107,9 +108,14 @@ pub mod type_keys {
     pub const TRANSFORM_SPACE_CONSTRAINT: u16 = 90;
     pub const WORLD_TRANSFORM_COMPONENT: u16 = 91;
     pub const NESTED_ARTBOARD: u16 = 92;
+    pub const NESTED_ANIMATION: u16 = 93;
+    pub const NESTED_STATE_MACHINE: u16 = 95;
     pub const IMAGE: u16 = 100;
+    pub const STATE_MACHINE_LISTENER: u16 = 114;
+    pub const LISTENER_BOOL_CHANGE: u16 = 117;
     pub const CUBIC_VALUE_INTERPOLATOR: u16 = 138;
     pub const CUBIC_INTERPOLATOR: u16 = 139;
+    pub const SOLO: u16 = 147;
     pub const INTERPOLATING_KEY_FRAME: u16 = 170;
     pub const KEYFRAME_INTERPOLATOR: u16 = 175;
     pub const LAYOUT_COMPONENT: u16 = 409;
@@ -196,6 +202,7 @@ pub mod property_keys {
     pub const TRIM_PATH_END: u16 = 115;
     pub const TRIM_PATH_OFFSET: u16 = 116;
     pub const TRIM_PATH_MODE_VALUE: u16 = 117;
+    pub const KEY_FRAME_ID_VALUE: u16 = 122;
     pub const PARAMETRIC_PATH_ORIGIN_X: u16 = 123;
     pub const PARAMETRIC_PATH_ORIGIN_Y: u16 = 124;
     pub const PATH_FLAGS: u16 = 128;
@@ -217,6 +224,7 @@ pub mod property_keys {
     pub const RECTANGLE_LINK_CORNER_RADIUS: u16 = 164;
     pub const LAYOUT_COMPONENT_CLIP: u16 = 196;
     pub const NESTED_ARTBOARD_ARTBOARD_ID: u16 = 197;
+    pub const NESTED_ANIMATION_ID: u16 = 198;
     pub const ARTBOARD_DEFAULT_STATE_MACHINE_ID: u16 = 236;
     pub const LINEAR_ANIMATION_QUANTIZE: u16 = 376;
     pub const LAYOUT_COMPONENT_STYLE_ID: u16 = 494;
@@ -279,11 +287,17 @@ pub mod property_keys {
     pub const IMAGE_ASSET_ID: u16 = 206;
     pub const FILE_ASSET_CDN_BASE_URL: u16 = 362;
     pub const FILE_ASSET_CONTENTS_BYTES: u16 = 212;
+    pub const LISTENER_TARGET_ID: u16 = 224;
+    pub const LISTENER_TYPE_VALUE: u16 = 225;
+    pub const LISTENER_ACTION_ID: u16 = 226;
+    pub const LISTENER_INPUT_ID: u16 = 227;
+    pub const LISTENER_BOOL_VALUE: u16 = 228;
     pub const TEXT_ALIGN_VALUE: u16 = 281;
     pub const TEXT_SIZING_VALUE: u16 = 284;
     pub const TEXT_WIDTH: u16 = 285;
     pub const TEXT_HEIGHT: u16 = 286;
     pub const TEXT_OVERFLOW_VALUE: u16 = 287;
+    pub const SOLO_ACTIVE_COMPONENT_ID: u16 = 296;
     pub const TEXT_ORIGIN_X: u16 = 366;
     pub const TEXT_ORIGIN_Y: u16 = 367;
     pub const TEXT_PARAGRAPH_SPACING: u16 = 371;
@@ -500,6 +514,7 @@ pub fn property_backing_type(key: u16) -> Option<BackingType> {
         | property_keys::DRAWABLE_FLAGS
         | property_keys::STATE_MACHINE_BOOL_VALUE
         | property_keys::ANIMATION_STATE_ANIMATION_ID
+        | property_keys::NESTED_ANIMATION_ID
         | property_keys::STATE_TRANSITION_STATE_TO_ID
         | property_keys::STATE_TRANSITION_FLAGS
         | property_keys::TRANSITION_INPUT_CONDITION_INPUT_ID
@@ -561,7 +576,14 @@ pub fn property_backing_type(key: u16) -> Option<BackingType> {
         | property_keys::VIEW_MODEL_PROPERTY_TYPE_VALUE
         | property_keys::DATA_BIND_PROPERTY_KEY
         | property_keys::DATA_BIND_FLAGS
-        | property_keys::DATA_BIND_CONVERTER_ID => Some(BackingType::UInt),
+        | property_keys::DATA_BIND_CONVERTER_ID
+        | property_keys::KEY_FRAME_ID_VALUE
+        | property_keys::LISTENER_TARGET_ID
+        | property_keys::LISTENER_TYPE_VALUE
+        | property_keys::LISTENER_ACTION_ID
+        | property_keys::LISTENER_INPUT_ID
+        | property_keys::LISTENER_BOOL_VALUE
+        | property_keys::SOLO_ACTIVE_COMPONENT_ID => Some(BackingType::UInt),
 
         property_keys::SOLID_COLOR_VALUE
         | property_keys::GRADIENT_STOP_COLOR
@@ -659,6 +681,22 @@ mod tests {
             property_backing_type(property_keys::IMAGE_ASSET_ID),
             Some(BackingType::UInt)
         );
+        assert_eq!(
+            property_backing_type(property_keys::KEY_FRAME_ID_VALUE),
+            Some(BackingType::UInt)
+        );
+        assert_eq!(
+            property_backing_type(property_keys::NESTED_ANIMATION_ID),
+            Some(BackingType::UInt)
+        );
+        assert_eq!(
+            property_backing_type(property_keys::LISTENER_INPUT_ID),
+            Some(BackingType::UInt)
+        );
+        assert_eq!(
+            property_backing_type(property_keys::SOLO_ACTIVE_COMPONENT_ID),
+            Some(BackingType::UInt)
+        );
     }
 
     #[test]
@@ -740,6 +778,7 @@ mod tests {
         assert_eq!(type_keys::CUBIC_MIRRORED_VERTEX, 35);
         assert_eq!(type_keys::KEY_FRAME_COLOR, 37);
         assert_eq!(type_keys::TRANSFORM_COMPONENT, 38);
+        assert_eq!(type_keys::KEY_FRAME_ID, 50);
         assert_eq!(type_keys::STATE_MACHINE, 53);
         assert_eq!(type_keys::STATE_MACHINE_COMPONENT, 54);
         assert_eq!(type_keys::STATE_MACHINE_INPUT, 55);
@@ -761,9 +800,14 @@ mod tests {
         assert_eq!(type_keys::TRIM_PATH, 47);
         assert_eq!(type_keys::WORLD_TRANSFORM_COMPONENT, 91);
         assert_eq!(type_keys::NESTED_ARTBOARD, 92);
+        assert_eq!(type_keys::NESTED_ANIMATION, 93);
+        assert_eq!(type_keys::NESTED_STATE_MACHINE, 95);
         assert_eq!(type_keys::IMAGE, 100);
+        assert_eq!(type_keys::STATE_MACHINE_LISTENER, 114);
+        assert_eq!(type_keys::LISTENER_BOOL_CHANGE, 117);
         assert_eq!(type_keys::CUBIC_VALUE_INTERPOLATOR, 138);
         assert_eq!(type_keys::CUBIC_INTERPOLATOR, 139);
+        assert_eq!(type_keys::SOLO, 147);
         assert_eq!(type_keys::INTERPOLATING_KEY_FRAME, 170);
         assert_eq!(type_keys::KEYFRAME_INTERPOLATOR, 175);
         assert_eq!(type_keys::CUBIC_EASE_INTERPOLATOR, 28);

--- a/src/objects/shapes.rs
+++ b/src/objects/shapes.rs
@@ -7,6 +7,14 @@ pub struct Node {
     pub y: f32,
 }
 
+pub struct Solo {
+    pub name: String,
+    pub parent_id: u64,
+    pub x: f32,
+    pub y: f32,
+    pub active_component_id: u64,
+}
+
 impl RiveObject for Node {
     fn type_key(&self) -> u16 {
         type_keys::NODE
@@ -33,6 +41,44 @@ impl RiveObject for Node {
             props.push(Property {
                 key: property_keys::NODE_Y,
                 value: PropertyValue::Float(self.y),
+            });
+        }
+        props
+    }
+}
+
+impl RiveObject for Solo {
+    fn type_key(&self) -> u16 {
+        type_keys::SOLO
+    }
+
+    fn properties(&self) -> Vec<Property> {
+        let mut props = vec![
+            Property {
+                key: property_keys::COMPONENT_NAME,
+                value: PropertyValue::String(self.name.clone()),
+            },
+            Property {
+                key: property_keys::COMPONENT_PARENT_ID,
+                value: PropertyValue::UInt(self.parent_id),
+            },
+        ];
+        if self.x != 0.0 {
+            props.push(Property {
+                key: property_keys::NODE_X,
+                value: PropertyValue::Float(self.x),
+            });
+        }
+        if self.y != 0.0 {
+            props.push(Property {
+                key: property_keys::NODE_Y,
+                value: PropertyValue::Float(self.y),
+            });
+        }
+        if self.active_component_id != 0 {
+            props.push(Property {
+                key: property_keys::SOLO_ACTIVE_COMPONENT_ID,
+                value: PropertyValue::UInt(self.active_component_id),
             });
         }
         props
@@ -1398,6 +1444,59 @@ mod tests {
             y: 0.0,
         };
         assert_eq!(node.type_key(), 2);
+    }
+
+    #[test]
+    fn test_solo_type_key() {
+        let solo = Solo {
+            name: "SoloNode".to_string(),
+            parent_id: 1,
+            x: 0.0,
+            y: 0.0,
+            active_component_id: 0,
+        };
+        assert_eq!(solo.type_key(), type_keys::SOLO);
+    }
+
+    #[test]
+    fn test_solo_properties_default_omission() {
+        let solo = Solo {
+            name: "SoloNode".to_string(),
+            parent_id: 1,
+            x: 0.0,
+            y: 0.0,
+            active_component_id: 0,
+        };
+        let props = solo.properties();
+        assert_eq!(props.len(), 2);
+        assert_eq!(props[0].key, property_keys::COMPONENT_NAME);
+        assert_eq!(props[1].key, property_keys::COMPONENT_PARENT_ID);
+        assert!(!props.iter().any(|p| p.key == property_keys::NODE_X));
+        assert!(!props.iter().any(|p| p.key == property_keys::NODE_Y));
+        assert!(
+            !props
+                .iter()
+                .any(|p| p.key == property_keys::SOLO_ACTIVE_COMPONENT_ID)
+        );
+    }
+
+    #[test]
+    fn test_solo_properties_with_active_component() {
+        let solo = Solo {
+            name: "SoloNode".to_string(),
+            parent_id: 2,
+            x: 12.0,
+            y: 24.0,
+            active_component_id: 5,
+        };
+        let props = solo.properties();
+        assert_eq!(props.len(), 5);
+        assert_eq!(props[2].key, property_keys::NODE_X);
+        assert_eq!(props[2].value, PropertyValue::Float(12.0));
+        assert_eq!(props[3].key, property_keys::NODE_Y);
+        assert_eq!(props[3].value, PropertyValue::Float(24.0));
+        assert_eq!(props[4].key, property_keys::SOLO_ACTIVE_COMPONENT_ID);
+        assert_eq!(props[4].value, PropertyValue::UInt(5));
     }
 
     #[test]

--- a/src/objects/state_machine.rs
+++ b/src/objects/state_machine.rs
@@ -139,6 +139,87 @@ impl RiveObject for StateMachineLayer {
     }
 }
 
+pub struct StateMachineListener {
+    pub target_id: u64,
+    pub listener_type_value: u64,
+}
+
+impl RiveObject for StateMachineListener {
+    fn type_key(&self) -> u16 {
+        type_keys::STATE_MACHINE_LISTENER
+    }
+
+    fn properties(&self) -> Vec<Property> {
+        let mut props = Vec::new();
+        if self.target_id != 0 {
+            props.push(Property {
+                key: property_keys::LISTENER_TARGET_ID,
+                value: PropertyValue::UInt(self.target_id),
+            });
+        }
+        if self.listener_type_value != 0 {
+            props.push(Property {
+                key: property_keys::LISTENER_TYPE_VALUE,
+                value: PropertyValue::UInt(self.listener_type_value),
+            });
+        }
+        props
+    }
+}
+
+pub struct ListenerBoolChange {
+    pub input_id: u64,
+    pub value: u64,
+}
+
+impl RiveObject for ListenerBoolChange {
+    fn type_key(&self) -> u16 {
+        type_keys::LISTENER_BOOL_CHANGE
+    }
+
+    fn properties(&self) -> Vec<Property> {
+        vec![
+            Property {
+                key: property_keys::LISTENER_INPUT_ID,
+                value: PropertyValue::UInt(self.input_id),
+            },
+            Property {
+                key: property_keys::LISTENER_BOOL_VALUE,
+                value: PropertyValue::UInt(self.value),
+            },
+        ]
+    }
+}
+
+pub struct NestedStateMachine {
+    pub name: String,
+    pub parent_id: u64,
+    pub animation_id: u64,
+}
+
+impl RiveObject for NestedStateMachine {
+    fn type_key(&self) -> u16 {
+        type_keys::NESTED_STATE_MACHINE
+    }
+
+    fn properties(&self) -> Vec<Property> {
+        vec![
+            Property {
+                key: property_keys::COMPONENT_NAME,
+                value: PropertyValue::String(self.name.clone()),
+            },
+            Property {
+                key: property_keys::COMPONENT_PARENT_ID,
+                value: PropertyValue::UInt(self.parent_id),
+            },
+            Property {
+                key: property_keys::NESTED_ANIMATION_ID,
+                value: PropertyValue::UInt(self.animation_id),
+            },
+        ]
+    }
+}
+
 pub struct EntryState;
 
 impl RiveObject for EntryState {
@@ -491,6 +572,66 @@ mod tests {
         let props = l.properties();
         assert_eq!(props.len(), 1);
         assert_eq!(props[0].key, 138);
+    }
+
+    #[test]
+    fn test_state_machine_listener_properties_default_omission() {
+        let listener = StateMachineListener {
+            target_id: 0,
+            listener_type_value: 0,
+        };
+        assert_eq!(listener.type_key(), type_keys::STATE_MACHINE_LISTENER);
+        assert!(listener.properties().is_empty());
+    }
+
+    #[test]
+    fn test_state_machine_listener_properties() {
+        let listener = StateMachineListener {
+            target_id: 3,
+            listener_type_value: 1,
+        };
+        let props = listener.properties();
+        assert_eq!(props.len(), 2);
+        assert_eq!(props[0].key, property_keys::LISTENER_TARGET_ID);
+        assert_eq!(props[0].value, PropertyValue::UInt(3));
+        assert_eq!(props[1].key, property_keys::LISTENER_TYPE_VALUE);
+        assert_eq!(props[1].value, PropertyValue::UInt(1));
+    }
+
+    #[test]
+    fn test_listener_bool_change_properties() {
+        let action = ListenerBoolChange {
+            input_id: 2,
+            value: 1,
+        };
+        assert_eq!(action.type_key(), type_keys::LISTENER_BOOL_CHANGE);
+        let props = action.properties();
+        assert_eq!(props.len(), 2);
+        assert_eq!(props[0].key, property_keys::LISTENER_INPUT_ID);
+        assert_eq!(props[0].value, PropertyValue::UInt(2));
+        assert_eq!(props[1].key, property_keys::LISTENER_BOOL_VALUE);
+        assert_eq!(props[1].value, PropertyValue::UInt(1));
+    }
+
+    #[test]
+    fn test_nested_state_machine_properties() {
+        let nested = NestedStateMachine {
+            name: "NestedSM".to_string(),
+            parent_id: 5,
+            animation_id: 9,
+        };
+        assert_eq!(nested.type_key(), type_keys::NESTED_STATE_MACHINE);
+        let props = nested.properties();
+        assert_eq!(props.len(), 3);
+        assert_eq!(props[0].key, property_keys::COMPONENT_NAME);
+        assert_eq!(
+            props[0].value,
+            PropertyValue::String("NestedSM".to_string())
+        );
+        assert_eq!(props[1].key, property_keys::COMPONENT_PARENT_ID);
+        assert_eq!(props[1].value, PropertyValue::UInt(5));
+        assert_eq!(props[2].key, property_keys::NESTED_ANIMATION_ID);
+        assert_eq!(props[2].value, PropertyValue::UInt(9));
     }
 
     #[test]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -124,6 +124,93 @@ fn test_generate_state_machine() {
 }
 
 #[test]
+fn test_generate_validate_solo_test() {
+    let input = fixture_path("solo_test.json");
+    let output = temp_output("solo_test");
+    cleanup(&output);
+
+    let generate = cargo_run(&[
+        "generate",
+        input.to_str().unwrap(),
+        "-o",
+        output.to_str().unwrap(),
+    ]);
+    assert!(
+        generate.status.success(),
+        "generate failed: {}",
+        String::from_utf8_lossy(&generate.stderr)
+    );
+
+    let validate = cargo_run(&["validate", output.to_str().unwrap()]);
+    assert!(
+        validate.status.success(),
+        "validate failed: {}",
+        String::from_utf8_lossy(&validate.stderr)
+    );
+
+    let inspect = cargo_run(&["inspect", output.to_str().unwrap()]);
+    let stdout = String::from_utf8_lossy(&inspect.stdout);
+    assert!(
+        inspect.status.success(),
+        "inspect failed: {}",
+        String::from_utf8_lossy(&inspect.stderr)
+    );
+    assert!(
+        stdout.contains("Solo"),
+        "expected 'Solo' in inspect output, got: {}",
+        stdout
+    );
+
+    cleanup(&output);
+}
+
+#[test]
+fn test_generate_validate_listener_test() {
+    let input = fixture_path("listener_test.json");
+    let output = temp_output("listener_test");
+    cleanup(&output);
+
+    let generate = cargo_run(&[
+        "generate",
+        input.to_str().unwrap(),
+        "-o",
+        output.to_str().unwrap(),
+    ]);
+    assert!(
+        generate.status.success(),
+        "generate failed: {}",
+        String::from_utf8_lossy(&generate.stderr)
+    );
+
+    let validate = cargo_run(&["validate", output.to_str().unwrap()]);
+    assert!(
+        validate.status.success(),
+        "validate failed: {}",
+        String::from_utf8_lossy(&validate.stderr)
+    );
+
+    let inspect = cargo_run(&["inspect", output.to_str().unwrap()]);
+    let stdout = String::from_utf8_lossy(&inspect.stdout);
+    assert!(
+        inspect.status.success(),
+        "inspect failed: {}",
+        String::from_utf8_lossy(&inspect.stderr)
+    );
+    assert!(
+        stdout.contains("StateMachineListener"),
+        "expected 'StateMachineListener' in inspect output, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("ListenerBoolChange"),
+        "expected 'ListenerBoolChange' in inspect output, got: {}",
+        stdout
+    );
+
+    cleanup(&output);
+}
+
+#[test]
 fn test_generate_path() {
     let input = fixture_path("path.json");
     let output = temp_output("path");

--- a/tests/fixtures/listener_test.json
+++ b/tests/fixtures/listener_test.json
@@ -1,0 +1,66 @@
+{
+  "scene_format_version": 1,
+  "artboard": {
+    "name": "ListenerDemo",
+    "width": 320,
+    "height": 240,
+    "children": [
+      {
+        "type": "shape",
+        "name": "TapTarget",
+        "x": 160,
+        "y": 120,
+        "children": [
+          {
+            "type": "ellipse",
+            "name": "TapTargetPath",
+            "width": 120,
+            "height": 120,
+            "origin_x": 0.5,
+            "origin_y": 0.5
+          },
+          {
+            "type": "fill",
+            "name": "TapTargetFill",
+            "children": [
+              {
+                "type": "solid_color",
+                "name": "TapTargetColor",
+                "color": "#16A34A"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "state_machines": [
+      {
+        "name": "InputMachine",
+        "inputs": [
+          { "type": "bool", "name": "is_active", "value": false }
+        ],
+        "listeners": [
+          {
+            "target": "TapTarget",
+            "listener_type_value": 1,
+            "actions": [
+              {
+                "type": "bool_change",
+                "input": "is_active",
+                "value": true
+              }
+            ]
+          }
+        ],
+        "layers": [
+          {
+            "states": [
+              { "type": "entry" },
+              { "type": "exit" }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/solo_test.json
+++ b/tests/fixtures/solo_test.json
@@ -1,0 +1,88 @@
+{
+  "scene_format_version": 1,
+  "artboard": {
+    "name": "SoloDemo",
+    "width": 400,
+    "height": 300,
+    "children": [
+      {
+        "type": "solo",
+        "name": "Switcher",
+        "x": 200,
+        "y": 150,
+        "active_component": "OptionA",
+        "children": [
+          {
+            "type": "shape",
+            "name": "OptionA",
+            "children": [
+              {
+                "type": "ellipse",
+                "name": "OptionAPath",
+                "width": 120,
+                "height": 120,
+                "origin_x": 0.5,
+                "origin_y": 0.5
+              },
+              {
+                "type": "fill",
+                "name": "OptionAFill",
+                "children": [
+                  {
+                    "type": "solid_color",
+                    "name": "OptionAColor",
+                    "color": "#FF6B35"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "shape",
+            "name": "OptionB",
+            "children": [
+              {
+                "type": "rectangle",
+                "name": "OptionBPath",
+                "width": 120,
+                "height": 120,
+                "origin_x": 0.5,
+                "origin_y": 0.5,
+                "corner_radius": 18
+              },
+              {
+                "type": "fill",
+                "name": "OptionBFill",
+                "children": [
+                  {
+                    "type": "solid_color",
+                    "name": "OptionBColor",
+                    "color": "#1D4ED8"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "animations": [
+      {
+        "name": "toggle_active",
+        "fps": 60,
+        "duration": 60,
+        "keyframes": [
+          {
+            "object": "Switcher",
+            "property": "active_component_id",
+            "frames": [
+              { "frame": 0, "value": 2 },
+              { "frame": 30, "value": 5 },
+              { "frame": 59, "value": 2 }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Implements **5 new Rive object types** closing the next batch of gaps from scanning 243 official .riv files:
  - **Solo** (type 147) — visibility switch container, activates one child at a time via `activeComponentId`
  - **KeyFrameId** (type 50) — uint-valued keyframe for ID-based animations (e.g. Solo child switching)
  - **StateMachineListener** (type 114) — event listener targeting artboard objects (hover, click, etc.)
  - **ListenerBoolChange** (type 117) — listener action that sets a StateMachineBool input
  - **NestedStateMachine** (type 95) — state machine reference in nested artboards

## Key Implementation Details

- Builder auto-selects `KeyFrameId` for uint-backed properties (vs `KeyFrameDouble` for float, `KeyFrameColor` for color)
- State machine JSON gains `listeners` array with typed `actions` (currently `bool_change`)
- Solo resolves `active_component` name to object index at build time
- All property keys cross-referenced against C++ runtime `*_base.hpp` headers
- `LISTENER_BOOL_VALUE` (key 228) intentionally NOT treated as bool-property — it's `CoreUintType` in C++ despite the name

## Type Gap Impact

| Type | Official .riv files needing it |
|------|-------------------------------|
| StateMachineListener | 14 |
| ListenerBoolChange | 11 |
| NestedStateMachine | 11 |
| KeyFrameId | 11 |
| Solo | 9 |

## Testing

- 349 unit tests + 92 e2e tests pass (was 331 + 90)
- New fixtures: `solo_test.json`, `listener_test.json`
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean
- Generate → validate → inspect roundtrip verified for both new fixtures

Closes part of #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solo objects for component switching and active component control
  * Added state machine listeners to trigger actions on events
  * Introduced listener bool-change actions for state transitions
  * Added support for nested state machines referencing animations
  * Expanded keyframe types to support color and integer data storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->