### PR TITLE
refactor: rewrite race script for local CLI dispatch

### DIFF
--- a/scripts/run_race.sh
+++ b/scripts/run_race.sh
@@ -146,6 +146,7 @@ echo ""
 ATTEMPTED_MODELS=0
 SUCCESSFUL_MODELS=0
 BEST_MODEL=""
+BEST_JSON_OUT=""
 BEST_OBJECTS=0
 ATTEMPTED_MODEL_NAMES=""
 
@@ -191,7 +192,7 @@ $USER_PROMPT"
     fi
 
     if [ "$CALL_OK" -eq 0 ]; then
-        echo "  FAIL: API call failed for $MODEL_NAME"
+        echo "  FAIL: CLI call failed for $MODEL_NAME"
         continue
     fi
 
@@ -232,6 +233,7 @@ $USER_PROMPT"
         if [ "$OBJ_COUNT" -gt "$BEST_OBJECTS" ]; then
             BEST_OBJECTS=$OBJ_COUNT
             BEST_MODEL="$MODEL_NAME-$CATEGORY"
+            BEST_JSON_OUT="$JSON_OUT"
         fi
     fi
 
@@ -258,8 +260,8 @@ echo "Models: $ATTEMPTED_MODELS attempted, $SUCCESSFUL_MODELS successful"
 if [ -n "$BEST_MODEL" ]; then
     echo "Best: $BEST_MODEL ($BEST_OBJECTS objects)"
     echo ""
-    echo "Winner JSON: $RESULTS_DIR/$(echo "$BEST_MODEL" | cut -d- -f1).json"
-    echo "To commit as fixture: cp $RESULTS_DIR/$(echo "$BEST_MODEL" | cut -d- -f1).json tests/fixtures/${TARGET_NAME}.json"
+    echo "Winner JSON: $BEST_JSON_OUT"
+    echo "To commit as fixture: cp $BEST_JSON_OUT tests/fixtures/${TARGET_NAME}.json"
 else
     echo "No successful outputs. Check CLI tool output and skill content."
 fi

--- a/scripts/run_race.sh
+++ b/scripts/run_race.sh
@@ -171,15 +171,18 @@ for model_spec in "${MODELS[@]}"; do
 
     # Call the model via local CLI
     CALL_OK=0
+    ERR_OUT="$RESULTS_DIR/${MODEL_NAME}.stderr.log"
+    rm -f "$ERR_OUT"
     if [ "$CLI_NAME" = "codex" ]; then
         FULL_PROMPT="$SYSTEM_PROMPT
 
 $USER_PROMPT"
         "$TIMEOUT_BIN" 300 codex exec \
             -m "$MODEL_ID" \
-            --full-auto \
+            --sandbox read-only \
+            -C "$PROJECT_ROOT" \
             -o "$JSON_OUT" \
-            "$FULL_PROMPT" 2>/dev/null && CALL_OK=1
+            "$FULL_PROMPT" 2>"$ERR_OUT" && CALL_OK=1
     elif [ "$CLI_NAME" = "claude" ]; then
         "$TIMEOUT_BIN" 300 claude -p \
             --model "$MODEL_ID" \
@@ -188,13 +191,15 @@ $USER_PROMPT"
             --no-session-persistence \
             --allowedTools "" \
             --max-budget-usd 5 \
-            "$USER_PROMPT" > "$JSON_OUT" 2>/dev/null && CALL_OK=1
+            "$USER_PROMPT" > "$JSON_OUT" 2>"$ERR_OUT" && CALL_OK=1
     fi
 
     if [ "$CALL_OK" -eq 0 ]; then
-        echo "  FAIL: CLI call failed for $MODEL_NAME"
+        echo "  FAIL: CLI call failed for $MODEL_NAME (see $ERR_OUT)"
         continue
     fi
+
+    rm -f "$ERR_OUT"
 
     # Strip markdown fences if present (only first/last lines)
     if head -1 "$JSON_OUT" | grep -q '^```'; then

--- a/scripts/run_race.sh
+++ b/scripts/run_race.sh
@@ -189,7 +189,6 @@ $USER_PROMPT"
             --system-prompt "$SYSTEM_PROMPT" \
             --output-format text \
             --no-session-persistence \
-            --allowedTools "" \
             --max-budget-usd 5 \
             "$USER_PROMPT" > "$JSON_OUT" 2>"$ERR_OUT" && CALL_OK=1
     fi

--- a/scripts/run_race.sh
+++ b/scripts/run_race.sh
@@ -179,6 +179,7 @@ for model_spec in "${MODELS[@]}"; do
 $USER_PROMPT"
         "$TIMEOUT_BIN" 300 codex exec \
             -m "$MODEL_ID" \
+            --ask-for-approval never \
             --sandbox read-only \
             -C "$PROJECT_ROOT" \
             -o "$JSON_OUT" \
@@ -189,6 +190,7 @@ $USER_PROMPT"
             --system-prompt "$SYSTEM_PROMPT" \
             --output-format text \
             --no-session-persistence \
+            --tools "" \
             --max-budget-usd 5 \
             "$USER_PROMPT" > "$JSON_OUT" 2>"$ERR_OUT" && CALL_OK=1
     fi
@@ -197,8 +199,6 @@ $USER_PROMPT"
         echo "  FAIL: CLI call failed for $MODEL_NAME (see $ERR_OUT)"
         continue
     fi
-
-    rm -f "$ERR_OUT"
 
     # Strip markdown fences if present (only first/last lines)
     if head -1 "$JSON_OUT" | grep -q '^```'; then
@@ -212,13 +212,13 @@ $USER_PROMPT"
 
     # Validate JSON syntax
     if ! jq empty "$JSON_OUT" 2>/dev/null; then
-        echo "  FAIL: Invalid JSON output"
+        echo "  FAIL: Invalid JSON output (see $ERR_OUT)"
         continue
     fi
 
     # Validate scene_format_version
     if ! jq -e '(.scene_format_version | type == "number") and (.scene_format_version == 1)' "$JSON_OUT" >/dev/null 2>&1; then
-        echo "  FAIL: Missing or invalid scene_format_version (must be 1)"
+        echo "  FAIL: Missing or invalid scene_format_version (must be 1; see $ERR_OUT)"
         continue
     fi
 
@@ -231,6 +231,7 @@ $USER_PROMPT"
 
     # Track best model by object count
     if echo "$ATTEMPT_RESULT" | grep -q "^OK"; then
+        rm -f "$ERR_OUT"
         SUCCESSFUL_MODELS=$((SUCCESSFUL_MODELS + 1))
         OBJ_COUNT=$(echo "$ATTEMPT_RESULT" | sed -n 's/.*objects=\([0-9]*\).*/\1/p')
         OBJ_COUNT="${OBJ_COUNT:-0}"

--- a/scripts/run_race.sh
+++ b/scripts/run_race.sh
@@ -8,6 +8,7 @@
 # Prerequisites:
 #   - At least one CLI tool installed: claude, codex
 #   - jq, sqlite3, python3 installed
+#   - timeout or gtimeout installed
 #   - cargo build passes
 #
 # Models are dispatched via local CLI tools:
@@ -30,6 +31,15 @@ for cmd in jq sqlite3 python3; do
         exit 1
     fi
 done
+
+if command -v timeout &>/dev/null; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout &>/dev/null; then
+    TIMEOUT_BIN="gtimeout"
+else
+    echo "ERROR: Required tool 'timeout' not found. Install GNU coreutils ('timeout' or 'gtimeout')."
+    exit 1
+fi
 
 # Warn about optional CLI tools
 for cmd in claude codex; do
@@ -65,6 +75,7 @@ if [ ! -f "$DB" ]; then
 fi
 
 mkdir -p "$RESULTS_DIR"
+cd "$PROJECT_ROOT"
 
 # Build skills context from .opencode/skills/
 SKILLS_CONTEXT=""
@@ -163,13 +174,13 @@ for model_spec in "${MODELS[@]}"; do
         FULL_PROMPT="$SYSTEM_PROMPT
 
 $USER_PROMPT"
-        timeout 300 codex exec \
+        "$TIMEOUT_BIN" 300 codex exec \
             -m "$MODEL_ID" \
             --full-auto \
             -o "$JSON_OUT" \
             "$FULL_PROMPT" 2>/dev/null && CALL_OK=1
     elif [ "$CLI_NAME" = "claude" ]; then
-        timeout 300 claude -p \
+        "$TIMEOUT_BIN" 300 claude -p \
             --model "$MODEL_ID" \
             --system-prompt "$SYSTEM_PROMPT" \
             --output-format text \

--- a/scripts/run_race.sh
+++ b/scripts/run_race.sh
@@ -6,29 +6,35 @@
 # is validated, logged to the SQLite ledger, and persisted to docs/race-results/.
 #
 # Prerequisites:
-#   - At least one model API key set (see Model Configuration below)
-#   - jq, curl, sqlite3, python3 installed
+#   - At least one CLI tool installed: claude, codex
+#   - jq, sqlite3, python3 installed
 #   - cargo build passes
 #
-# Model Configuration (via environment variables):
-#   OPENAI_API_KEY     — enables Codex model (gpt-4.1)
-#   GEMINI_API_KEY     — enables Gemini model (gemini-2.5-pro)
-#   ANTHROPIC_API_KEY  — enables Opus model (claude-opus-4-6)
+# Models are dispatched via local CLI tools:
+#   codex  — Codex model (gpt-5.4)
+#   claude — Opus model (claude opus)
 #
-# Models without API keys are skipped with a warning.
+# CLIs not found on PATH are skipped with a warning.
 #
 # Examples:
 #   ./scripts/run_race.sh loader "spinning loading indicator with smooth rotation"
 #   ./scripts/run_race.sh icon_set "3 simple icons: home, settings, profile" static
-#   OPENAI_API_KEY=sk-... ./scripts/run_race.sh game_hud "health bar and score counter" animated
+#   ./scripts/run_race.sh game_hud "health bar and score counter" animated
 
 set -euo pipefail
 
 # Check required tools
-for cmd in jq curl sqlite3 python3; do
+for cmd in jq sqlite3 python3; do
     if ! command -v "$cmd" &>/dev/null; then
         echo "ERROR: Required tool '$cmd' not found. Please install it."
         exit 1
+    fi
+done
+
+# Warn about optional CLI tools
+for cmd in claude codex; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "WARNING: Optional CLI tool '$cmd' not found — its model will be skipped."
     fi
 done
 
@@ -114,11 +120,10 @@ USER_PROMPT="Create a Rive scene: $PROMPT
 Target name: $TARGET_NAME
 Complexity tier: $COMPLEXITY"
 
-# Model definitions: name|api_key_env|endpoint|model_id|category
+# Model definitions: name|cli_name|model_id|category
 declare -a MODELS=(
-    "codex|OPENAI_API_KEY|https://api.openai.com/v1/chat/completions|gpt-4.1|deep"
-    "gemini|GEMINI_API_KEY|https://generativelanguage.googleapis.com/v1beta/openai/chat/completions|gemini-2.5-pro|artistry"
-    "opus|ANTHROPIC_API_KEY|https://api.anthropic.com/v1/messages|claude-opus-4-6|unspecified-high"
+    "codex|codex|gpt-5.4|deep"
+    "opus|claude|opus|artistry"
 )
 
 echo "=== Race: $TARGET_NAME ==="
@@ -134,11 +139,10 @@ BEST_OBJECTS=0
 ATTEMPTED_MODEL_NAMES=""
 
 for model_spec in "${MODELS[@]}"; do
-    IFS='|' read -r MODEL_NAME API_KEY_ENV ENDPOINT MODEL_ID CATEGORY <<< "$model_spec"
-    API_KEY="${!API_KEY_ENV:-}"
+    IFS='|' read -r MODEL_NAME CLI_NAME MODEL_ID CATEGORY <<< "$model_spec"
 
-    if [ -z "$API_KEY" ]; then
-        echo "SKIP $MODEL_NAME — $API_KEY_ENV not set"
+    if ! command -v "$CLI_NAME" &>/dev/null; then
+        echo "SKIP $MODEL_NAME — '$CLI_NAME' CLI not found"
         continue
     fi
 
@@ -153,52 +157,26 @@ for model_spec in "${MODELS[@]}"; do
 
     echo "--- $MODEL_NAME ($MODEL_ID) ---"
 
-    # Call the model API
+    # Call the model via local CLI
     CALL_OK=0
-    if [ "$MODEL_NAME" = "opus" ]; then
-        # Anthropic uses a different API format
-        RESPONSE=$(curl -s --connect-timeout 30 --max-time 300 -w "\n%{http_code}" "$ENDPOINT" \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: $API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -d "$(jq -n \
-                --arg model "$MODEL_ID" \
-                --arg system "$SYSTEM_PROMPT" \
-                --arg user "$USER_PROMPT" \
-                '{model: $model, max_tokens: 8192, system: $system, messages: [{role: "user", content: $user}]}')" \
-            2>/dev/null) || true
+    if [ "$CLI_NAME" = "codex" ]; then
+        FULL_PROMPT="$SYSTEM_PROMPT
 
-        HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-        BODY=$(echo "$RESPONSE" | sed '$d')
-
-        if [ "$HTTP_CODE" = "200" ]; then
-            # Extract text from Anthropic response
-            echo "$BODY" | jq -r '.content[0].text' > "$JSON_OUT" 2>/dev/null && CALL_OK=1
-        else
-            echo "  API error (HTTP $HTTP_CODE)"
-            echo "$BODY" | head -3
-        fi
-    else
-        # OpenAI-compatible API (Codex, Gemini)
-        RESPONSE=$(curl -s --connect-timeout 30 --max-time 300 -w "\n%{http_code}" "$ENDPOINT" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer $API_KEY" \
-            -d "$(jq -n \
-                --arg model "$MODEL_ID" \
-                --arg system "$SYSTEM_PROMPT" \
-                --arg user "$USER_PROMPT" \
-                '{model: $model, max_tokens: 8192, messages: [{role: "system", content: $system}, {role: "user", content: $user}]}')" \
-            2>/dev/null) || true
-
-        HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-        BODY=$(echo "$RESPONSE" | sed '$d')
-
-        if [ "$HTTP_CODE" = "200" ]; then
-            echo "$BODY" | jq -r '.choices[0].message.content' > "$JSON_OUT" 2>/dev/null && CALL_OK=1
-        else
-            echo "  API error (HTTP $HTTP_CODE)"
-            echo "$BODY" | head -3
-        fi
+$USER_PROMPT"
+        timeout 300 codex exec \
+            -m "$MODEL_ID" \
+            --full-auto \
+            -o "$JSON_OUT" \
+            "$FULL_PROMPT" 2>/dev/null && CALL_OK=1
+    elif [ "$CLI_NAME" = "claude" ]; then
+        timeout 300 claude -p \
+            --model "$MODEL_ID" \
+            --system-prompt "$SYSTEM_PROMPT" \
+            --output-format text \
+            --no-session-persistence \
+            --allowedTools "" \
+            --max-budget-usd 5 \
+            "$USER_PROMPT" > "$JSON_OUT" 2>/dev/null && CALL_OK=1
     fi
 
     if [ "$CALL_OK" -eq 0 ]; then
@@ -250,8 +228,7 @@ for model_spec in "${MODELS[@]}"; do
 done
 
 if [ "$ATTEMPTED_MODELS" -eq 0 ]; then
-    echo "ERROR: No models produced valid output. Check API keys and responses."
-    echo "Set at least one of: OPENAI_API_KEY, GEMINI_API_KEY, ANTHROPIC_API_KEY"
+    echo "ERROR: No models were available. Install 'claude' and/or 'codex' CLI tools."
     exit 1
 fi
 
@@ -273,7 +250,7 @@ if [ -n "$BEST_MODEL" ]; then
     echo "Winner JSON: $RESULTS_DIR/$(echo "$BEST_MODEL" | cut -d- -f1).json"
     echo "To commit as fixture: cp $RESULTS_DIR/$(echo "$BEST_MODEL" | cut -d- -f1).json tests/fixtures/${TARGET_NAME}.json"
 else
-    echo "No successful outputs. Check API responses and skill content."
+    echo "No successful outputs. Check CLI tool output and skill content."
 fi
 echo ""
 echo "Ledger: sqlite3 $DB \"SELECT * FROM attempts WHERE run_id='$RUN_ID';\""

--- a/scripts/run_race.sh
+++ b/scripts/run_race.sh
@@ -212,13 +212,13 @@ $USER_PROMPT"
 
     # Validate JSON syntax
     if ! jq empty "$JSON_OUT" 2>/dev/null; then
-        echo "  FAIL: Invalid JSON output (see $ERR_OUT)"
+        echo "  FAIL: Invalid JSON output (check $JSON_OUT)"
         continue
     fi
 
     # Validate scene_format_version
     if ! jq -e '(.scene_format_version | type == "number") and (.scene_format_version == 1)' "$JSON_OUT" >/dev/null 2>&1; then
-        echo "  FAIL: Missing or invalid scene_format_version (must be 1; see $ERR_OUT)"
+        echo "  FAIL: Missing or invalid scene_format_version (must be 1)"
         continue
     fi
 


### PR DESCRIPTION
## Summary
- Replace `curl`-based HTTP API calls with local `claude -p` and `codex exec` CLI invocations
- Drop Gemini model (2 models: codex + opus)
- Remove API key env var checks — CLI availability is detected automatically
- Remove `curl` from prerequisites, add optional `claude`/`codex` warnings
- 42 insertions, 65 deletions (net -23 lines)

## Test plan
- [ ] `bash -n scripts/run_race.sh` — syntax valid
- [ ] Dry run: `./scripts/run_race.sh test_circle "a simple red circle" static`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched execution to local model CLIs, removing API-key reliance; invocations now run via detected CLIs with timeout wrapping and per-tool logging.
* **New Features**
  * Auto-detects available CLI tools, selects runtime targets, tracks per-model outputs, and records the best-performing model JSON path.
* **Bug Fixes**
  * Validates/sanitizes JSON output, strips markdown fences, enforces scene_format_version == 1, and improves per-tool error handling.
* **UX**
  * Clearer run metadata, messages about missing/skipped CLIs, failures, and the winning output path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->