### PR TITLE
refactor: harden encoder module — constants, visibility, dead code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ sha2 = "0.10"
 thiserror = "2"
 ureq = { version = "2", features = ["json"] }
 rmcp = { version = "0.16", optional = true, features = ["server", "transport-io", "macros"] }
-tokio = { version = "1", optional = true, features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", optional = true, features = ["rt-multi-thread", "macros", "fs"] }
 schemars = { version = "1", optional = true }
 
 [features]

--- a/src/encoder/binary_writer.rs
+++ b/src/encoder/binary_writer.rs
@@ -45,10 +45,6 @@ impl BinaryWriter {
         self.buffer.extend_from_slice(&bytes);
     }
 
-    pub fn write_uint(&mut self, value: u64) {
-        self.write_varuint(value);
-    }
-
     pub fn write_bool(&mut self, value: bool) {
         self.buffer.push(if value { 1 } else { 0 });
     }
@@ -146,13 +142,6 @@ mod tests {
         let mut writer = BinaryWriter::new();
         writer.write_bool(false);
         assert_eq!(writer.finish(), vec![0x00]);
-    }
-
-    #[test]
-    fn test_write_uint() {
-        let mut writer = BinaryWriter::new();
-        writer.write_uint(300);
-        assert_eq!(writer.finish(), vec![0xAC, 0x02]);
     }
 
     #[test]

--- a/src/encoder/header.rs
+++ b/src/encoder/header.rs
@@ -1,9 +1,12 @@
 use super::binary_writer::BinaryWriter;
 
-pub fn encode_header(file_id: u64) -> Vec<u8> {
+pub(crate) const RIVE_FINGERPRINT: &[u8; 4] = b"RIVE";
+pub(crate) const RIVE_MAJOR_VERSION: u64 = 7;
+
+pub(crate) fn encode_header(file_id: u64) -> Vec<u8> {
     let mut writer = BinaryWriter::new();
-    writer.write_bytes(&[0x52, 0x49, 0x56, 0x45]);
-    writer.write_varuint(7);
+    writer.write_bytes(RIVE_FINGERPRINT);
+    writer.write_varuint(RIVE_MAJOR_VERSION);
     writer.write_varuint(0);
     writer.write_varuint(file_id);
     writer.finish()

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -5,7 +5,7 @@ pub mod toc;
 use crate::objects::core::{PropertyValue, RiveObject, is_bool_property};
 use binary_writer::BinaryWriter;
 
-pub fn encode_object(object: &dyn RiveObject) -> Vec<u8> {
+pub(crate) fn encode_object(object: &dyn RiveObject) -> Vec<u8> {
     let mut writer = BinaryWriter::new();
     writer.write_varuint(object.type_key() as u64);
     for prop in object.properties() {

--- a/src/encoder/toc.rs
+++ b/src/encoder/toc.rs
@@ -10,7 +10,7 @@ fn backing_bits(backing_type: BackingType) -> u32 {
     }
 }
 
-pub fn encode_toc(property_keys: &[u16]) -> Vec<u8> {
+pub(crate) fn encode_toc(property_keys: &[u16]) -> Vec<u8> {
     let mut writer = BinaryWriter::new();
 
     for &key in property_keys {
@@ -26,7 +26,10 @@ pub fn encode_toc(property_keys: &[u16]) -> Vec<u8> {
                 let idx = chunk * 16 + i;
                 if idx < property_keys.len() {
                     let backing = property_backing_type(property_keys[idx])
-                        .unwrap_or_else(|| panic!("unknown property key: {}", property_keys[idx]));
+                        .unwrap_or_else(|| panic!(
+                            "property key {} has no known backing type — register it in core::property_backing_type()",
+                            property_keys[idx]
+                        ));
                     val |= backing_bits(backing) << (i * 2);
                 }
             }


### PR DESCRIPTION
## Summary
- **Improved panic message in `toc.rs`**: replaced generic "unknown property key" message with actionable guidance pointing developers to `core::property_backing_type()` for registration.
- **Defined header constants**: added `RIVE_FINGERPRINT` and `RIVE_MAJOR_VERSION` in `encoder/header.rs`, replacing hardcoded magic bytes and version number `7`.
- **Removed dead code**: deleted `BinaryWriter::write_uint()`, a trivial alias for `write_varuint` that added no value.
- **Narrowed visibility**: changed `encode_object()`, `encode_header()`, `encode_toc()` from `pub` to `pub(crate)` since they are internal to the encoder module.
- **Fixed MCP build**: added missing `"fs"` feature to the tokio dependency, fixing a pre-existing compilation error with `cargo build --features mcp`.

## Test plan
- [x] `cargo test` — all 112 tests pass
- [x] `cargo build --features mcp` — compiles successfully
- [x] `cargo run -- generate / validate / inspect` smoke test on `minimal.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message clarity when encountering unknown property keys, guiding users to register keys properly.

* **Refactor**
  * Simplified public API by making encoder functions internal-only for better encapsulation.
  * Removed deprecated write_uint method from BinaryWriter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->