### PR TITLE
feat: add --json output for generate, validate, and list-presets

### DIFF
--- a/src/ai/templates.rs
+++ b/src/ai/templates.rs
@@ -315,7 +315,7 @@ pub fn get_template(name: &str) -> Result<serde_json::Value, AiError> {
             return Err(AiError::UnknownTemplate {
                 name: name.to_string(),
                 available: list_templates().join(", "),
-            })
+            });
         }
     };
     serde_json::from_str(json_str).map_err(|e| AiError::InvalidResponse(e.to_string()))

--- a/src/builder/animations.rs
+++ b/src/builder/animations.rs
@@ -4,7 +4,9 @@ use crate::objects::animation::{
     CubicEaseInterpolator, ElasticInterpolator, KeyFrameBool, KeyFrameCallback, KeyFrameColor,
     KeyFrameDouble, KeyFrameId, KeyFrameString, KeyedObject, KeyedProperty, LinearAnimation,
 };
-use crate::objects::core::{BackingType, RiveObject, is_bool_property, property_backing_type, property_keys};
+use crate::objects::core::{
+    BackingType, RiveObject, is_bool_property, property_backing_type, property_keys,
+};
 
 use super::parsers::{
     interpolation_type_from_name, interpolator_def_equals, json_value_to_color, json_value_to_f32,
@@ -108,9 +110,9 @@ pub(crate) fn build_animations(
             let object_index = *object_name_to_index.get(&group.object).ok_or_else(|| {
                 format!("unknown object referenced in keyframes: '{}'", group.object)
             })?;
-            let keyed_object_id = object_index.checked_sub(artboard_start).ok_or(
-                "internal error: keyed object index precedes artboard start".to_string(),
-            )?;
+            let keyed_object_id = object_index
+                .checked_sub(artboard_start)
+                .ok_or("internal error: keyed object index precedes artboard start".to_string())?;
             objects.push(Box::new(KeyedObject {
                 object_id: keyed_object_id as u64,
             }));

--- a/src/builder/objects.rs
+++ b/src/builder/objects.rs
@@ -718,21 +718,51 @@ pub(crate) fn append_object(
             children,
         } => {
             let mut skin = Skin::new(name.clone(), parent_id);
-            if let Some(xx) = xx { skin.xx = *xx; }
-            if let Some(yx) = yx { skin.yx = *yx; }
-            if let Some(xy) = xy { skin.xy = *xy; }
-            if let Some(yy) = yy { skin.yy = *yy; }
-            if let Some(tx) = tx { skin.tx = *tx; }
-            if let Some(ty) = ty { skin.ty = *ty; }
+            if let Some(xx) = xx {
+                skin.xx = *xx;
+            }
+            if let Some(yx) = yx {
+                skin.yx = *yx;
+            }
+            if let Some(xy) = xy {
+                skin.xy = *xy;
+            }
+            if let Some(yy) = yy {
+                skin.yy = *yy;
+            }
+            if let Some(tx) = tx {
+                skin.tx = *tx;
+            }
+            if let Some(ty) = ty {
+                skin.ty = *ty;
+            }
             objects.push(Box::new(skin));
             name_to_index.insert(name.clone(), object_index);
             if let Some(children) = children {
                 for child in children {
-                    append_object(child, object_index, artboard_start, objects, name_to_index, artboard_name_to_index, current_artboard_name, animation_name_to_index)?;
+                    append_object(
+                        child,
+                        object_index,
+                        artboard_start,
+                        objects,
+                        name_to_index,
+                        artboard_name_to_index,
+                        current_artboard_name,
+                        animation_name_to_index,
+                    )?;
                 }
             }
         }
-        ObjectSpec::Tendon { name, bone, xx, yx, xy, yy, tx, ty } => {
+        ObjectSpec::Tendon {
+            name,
+            bone,
+            xx,
+            yx,
+            xy,
+            yy,
+            tx,
+            ty,
+        } => {
             let mut tendon = Tendon::new(name.clone(), parent_id);
             if let Some(bone_name) = bone {
                 let bone_global = *name_to_index.get(bone_name).ok_or_else(|| {
@@ -740,234 +770,645 @@ pub(crate) fn append_object(
                 })?;
                 tendon.bone_id = (bone_global - artboard_start) as u64;
             }
-            if let Some(xx) = xx { tendon.xx = *xx; }
-            if let Some(yx) = yx { tendon.yx = *yx; }
-            if let Some(xy) = xy { tendon.xy = *xy; }
-            if let Some(yy) = yy { tendon.yy = *yy; }
-            if let Some(tx) = tx { tendon.tx = *tx; }
-            if let Some(ty) = ty { tendon.ty = *ty; }
+            if let Some(xx) = xx {
+                tendon.xx = *xx;
+            }
+            if let Some(yx) = yx {
+                tendon.yx = *yx;
+            }
+            if let Some(xy) = xy {
+                tendon.xy = *xy;
+            }
+            if let Some(yy) = yy {
+                tendon.yy = *yy;
+            }
+            if let Some(tx) = tx {
+                tendon.tx = *tx;
+            }
+            if let Some(ty) = ty {
+                tendon.ty = *ty;
+            }
             objects.push(Box::new(tendon));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::Weight { name, values, indices } => {
+        ObjectSpec::Weight {
+            name,
+            values,
+            indices,
+        } => {
             let mut weight = Weight::new(name.clone(), parent_id);
-            if let Some(values) = values { weight.values = *values; }
-            if let Some(indices) = indices { weight.indices = *indices; }
+            if let Some(values) = values {
+                weight.values = *values;
+            }
+            if let Some(indices) = indices {
+                weight.indices = *indices;
+            }
             objects.push(Box::new(weight));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::CubicWeight { name, in_values, in_indices, out_values, out_indices } => {
+        ObjectSpec::CubicWeight {
+            name,
+            in_values,
+            in_indices,
+            out_values,
+            out_indices,
+        } => {
             let mut cubic_weight = CubicWeight::new(name.clone(), parent_id);
-            if let Some(in_values) = in_values { cubic_weight.in_values = *in_values; }
-            if let Some(in_indices) = in_indices { cubic_weight.in_indices = *in_indices; }
-            if let Some(out_values) = out_values { cubic_weight.out_values = *out_values; }
-            if let Some(out_indices) = out_indices { cubic_weight.out_indices = *out_indices; }
+            if let Some(in_values) = in_values {
+                cubic_weight.in_values = *in_values;
+            }
+            if let Some(in_indices) = in_indices {
+                cubic_weight.in_indices = *in_indices;
+            }
+            if let Some(out_values) = out_values {
+                cubic_weight.out_values = *out_values;
+            }
+            if let Some(out_indices) = out_indices {
+                cubic_weight.out_indices = *out_indices;
+            }
             objects.push(Box::new(cubic_weight));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::IkConstraint { name, target, strength, invert_direction, parent_bone_count } => {
+        ObjectSpec::IkConstraint {
+            name,
+            target,
+            strength,
+            invert_direction,
+            parent_bone_count,
+        } => {
             let mut ik = IKConstraint::new(name.clone(), parent_id);
             if let Some(target_name) = target {
-                let target_global = *name_to_index.get(target_name).ok_or_else(|| format!("ik_constraint '{}' references unknown target '{}'", name, target_name))?;
+                let target_global = *name_to_index.get(target_name).ok_or_else(|| {
+                    format!(
+                        "ik_constraint '{}' references unknown target '{}'",
+                        name, target_name
+                    )
+                })?;
                 ik.target_id = (target_global - artboard_start) as u64;
             }
-            if let Some(s) = strength { ik.strength = *s; }
-            if let Some(inv) = invert_direction { ik.invert_direction = *inv; }
-            if let Some(pbc) = parent_bone_count { ik.parent_bone_count = *pbc; }
+            if let Some(s) = strength {
+                ik.strength = *s;
+            }
+            if let Some(inv) = invert_direction {
+                ik.invert_direction = *inv;
+            }
+            if let Some(pbc) = parent_bone_count {
+                ik.parent_bone_count = *pbc;
+            }
             objects.push(Box::new(ik));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::DistanceConstraint { name, target, strength, distance, mode_value } => {
+        ObjectSpec::DistanceConstraint {
+            name,
+            target,
+            strength,
+            distance,
+            mode_value,
+        } => {
             let mut dc = DistanceConstraint::new(name.clone(), parent_id);
             if let Some(target_name) = target {
-                let target_global = *name_to_index.get(target_name).ok_or_else(|| format!("distance_constraint '{}' references unknown target '{}'", name, target_name))?;
+                let target_global = *name_to_index.get(target_name).ok_or_else(|| {
+                    format!(
+                        "distance_constraint '{}' references unknown target '{}'",
+                        name, target_name
+                    )
+                })?;
                 dc.target_id = (target_global - artboard_start) as u64;
             }
-            if let Some(s) = strength { dc.strength = *s; }
-            if let Some(d) = distance { dc.distance = *d; }
-            if let Some(mv) = mode_value { dc.mode_value = *mv; }
+            if let Some(s) = strength {
+                dc.strength = *s;
+            }
+            if let Some(d) = distance {
+                dc.distance = *d;
+            }
+            if let Some(mv) = mode_value {
+                dc.mode_value = *mv;
+            }
             objects.push(Box::new(dc));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::TransformConstraint { name, target, strength, source_space_value, dest_space_value, origin_x, origin_y } => {
+        ObjectSpec::TransformConstraint {
+            name,
+            target,
+            strength,
+            source_space_value,
+            dest_space_value,
+            origin_x,
+            origin_y,
+        } => {
             let mut tc = TransformConstraint::new(name.clone(), parent_id);
             if let Some(target_name) = target {
-                let target_global = *name_to_index.get(target_name).ok_or_else(|| format!("transform_constraint '{}' references unknown target '{}'", name, target_name))?;
+                let target_global = *name_to_index.get(target_name).ok_or_else(|| {
+                    format!(
+                        "transform_constraint '{}' references unknown target '{}'",
+                        name, target_name
+                    )
+                })?;
                 tc.target_id = (target_global - artboard_start) as u64;
             }
-            if let Some(s) = strength { tc.strength = *s; }
-            if let Some(ssv) = source_space_value { tc.source_space_value = *ssv; }
-            if let Some(dsv) = dest_space_value { tc.dest_space_value = *dsv; }
-            if let Some(ox) = origin_x { tc.origin_x = *ox; }
-            if let Some(oy) = origin_y { tc.origin_y = *oy; }
+            if let Some(s) = strength {
+                tc.strength = *s;
+            }
+            if let Some(ssv) = source_space_value {
+                tc.source_space_value = *ssv;
+            }
+            if let Some(dsv) = dest_space_value {
+                tc.dest_space_value = *dsv;
+            }
+            if let Some(ox) = origin_x {
+                tc.origin_x = *ox;
+            }
+            if let Some(oy) = origin_y {
+                tc.origin_y = *oy;
+            }
             objects.push(Box::new(tc));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::TranslationConstraint { name, target, strength, source_space_value, dest_space_value, copy_factor, min_value, max_value, offset, does_copy, min, max, min_max_space_value, copy_factor_y, min_value_y, max_value_y, does_copy_y, min_y, max_y } => {
+        ObjectSpec::TranslationConstraint {
+            name,
+            target,
+            strength,
+            source_space_value,
+            dest_space_value,
+            copy_factor,
+            min_value,
+            max_value,
+            offset,
+            does_copy,
+            min,
+            max,
+            min_max_space_value,
+            copy_factor_y,
+            min_value_y,
+            max_value_y,
+            does_copy_y,
+            min_y,
+            max_y,
+        } => {
             let mut tlc = TranslationConstraint::new(name.clone(), parent_id);
             if let Some(target_name) = target {
-                let target_global = *name_to_index.get(target_name).ok_or_else(|| format!("translation_constraint '{}' references unknown target '{}'", name, target_name))?;
+                let target_global = *name_to_index.get(target_name).ok_or_else(|| {
+                    format!(
+                        "translation_constraint '{}' references unknown target '{}'",
+                        name, target_name
+                    )
+                })?;
                 tlc.target_id = (target_global - artboard_start) as u64;
             }
-            if let Some(s) = strength { tlc.strength = *s; }
-            if let Some(v) = source_space_value { tlc.source_space_value = *v; }
-            if let Some(v) = dest_space_value { tlc.dest_space_value = *v; }
-            if let Some(v) = copy_factor { tlc.copy_factor = *v; }
-            if let Some(v) = min_value { tlc.min_value = *v; }
-            if let Some(v) = max_value { tlc.max_value = *v; }
-            if let Some(v) = offset { tlc.offset = *v; }
-            if let Some(v) = does_copy { tlc.does_copy = *v; }
-            if let Some(v) = min { tlc.min = *v; }
-            if let Some(v) = max { tlc.max = *v; }
-            if let Some(v) = min_max_space_value { tlc.min_max_space_value = *v; }
-            if let Some(v) = copy_factor_y { tlc.copy_factor_y = *v; }
-            if let Some(v) = min_value_y { tlc.min_value_y = *v; }
-            if let Some(v) = max_value_y { tlc.max_value_y = *v; }
-            if let Some(v) = does_copy_y { tlc.does_copy_y = *v; }
-            if let Some(v) = min_y { tlc.min_y = *v; }
-            if let Some(v) = max_y { tlc.max_y = *v; }
+            if let Some(s) = strength {
+                tlc.strength = *s;
+            }
+            if let Some(v) = source_space_value {
+                tlc.source_space_value = *v;
+            }
+            if let Some(v) = dest_space_value {
+                tlc.dest_space_value = *v;
+            }
+            if let Some(v) = copy_factor {
+                tlc.copy_factor = *v;
+            }
+            if let Some(v) = min_value {
+                tlc.min_value = *v;
+            }
+            if let Some(v) = max_value {
+                tlc.max_value = *v;
+            }
+            if let Some(v) = offset {
+                tlc.offset = *v;
+            }
+            if let Some(v) = does_copy {
+                tlc.does_copy = *v;
+            }
+            if let Some(v) = min {
+                tlc.min = *v;
+            }
+            if let Some(v) = max {
+                tlc.max = *v;
+            }
+            if let Some(v) = min_max_space_value {
+                tlc.min_max_space_value = *v;
+            }
+            if let Some(v) = copy_factor_y {
+                tlc.copy_factor_y = *v;
+            }
+            if let Some(v) = min_value_y {
+                tlc.min_value_y = *v;
+            }
+            if let Some(v) = max_value_y {
+                tlc.max_value_y = *v;
+            }
+            if let Some(v) = does_copy_y {
+                tlc.does_copy_y = *v;
+            }
+            if let Some(v) = min_y {
+                tlc.min_y = *v;
+            }
+            if let Some(v) = max_y {
+                tlc.max_y = *v;
+            }
             objects.push(Box::new(tlc));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::ScaleConstraint { name, target, strength, source_space_value, dest_space_value, copy_factor, min_value, max_value, offset, does_copy, min, max, min_max_space_value, copy_factor_y, min_value_y, max_value_y, does_copy_y, min_y, max_y } => {
+        ObjectSpec::ScaleConstraint {
+            name,
+            target,
+            strength,
+            source_space_value,
+            dest_space_value,
+            copy_factor,
+            min_value,
+            max_value,
+            offset,
+            does_copy,
+            min,
+            max,
+            min_max_space_value,
+            copy_factor_y,
+            min_value_y,
+            max_value_y,
+            does_copy_y,
+            min_y,
+            max_y,
+        } => {
             let mut sc = ScaleConstraint::new(name.clone(), parent_id);
             if let Some(target_name) = target {
-                let target_global = *name_to_index.get(target_name).ok_or_else(|| format!("scale_constraint '{}' references unknown target '{}'", name, target_name))?;
+                let target_global = *name_to_index.get(target_name).ok_or_else(|| {
+                    format!(
+                        "scale_constraint '{}' references unknown target '{}'",
+                        name, target_name
+                    )
+                })?;
                 sc.target_id = (target_global - artboard_start) as u64;
             }
-            if let Some(s) = strength { sc.strength = *s; }
-            if let Some(v) = source_space_value { sc.source_space_value = *v; }
-            if let Some(v) = dest_space_value { sc.dest_space_value = *v; }
-            if let Some(v) = copy_factor { sc.copy_factor = *v; }
-            if let Some(v) = min_value { sc.min_value = *v; }
-            if let Some(v) = max_value { sc.max_value = *v; }
-            if let Some(v) = offset { sc.offset = *v; }
-            if let Some(v) = does_copy { sc.does_copy = *v; }
-            if let Some(v) = min { sc.min = *v; }
-            if let Some(v) = max { sc.max = *v; }
-            if let Some(v) = min_max_space_value { sc.min_max_space_value = *v; }
-            if let Some(v) = copy_factor_y { sc.copy_factor_y = *v; }
-            if let Some(v) = min_value_y { sc.min_value_y = *v; }
-            if let Some(v) = max_value_y { sc.max_value_y = *v; }
-            if let Some(v) = does_copy_y { sc.does_copy_y = *v; }
-            if let Some(v) = min_y { sc.min_y = *v; }
-            if let Some(v) = max_y { sc.max_y = *v; }
+            if let Some(s) = strength {
+                sc.strength = *s;
+            }
+            if let Some(v) = source_space_value {
+                sc.source_space_value = *v;
+            }
+            if let Some(v) = dest_space_value {
+                sc.dest_space_value = *v;
+            }
+            if let Some(v) = copy_factor {
+                sc.copy_factor = *v;
+            }
+            if let Some(v) = min_value {
+                sc.min_value = *v;
+            }
+            if let Some(v) = max_value {
+                sc.max_value = *v;
+            }
+            if let Some(v) = offset {
+                sc.offset = *v;
+            }
+            if let Some(v) = does_copy {
+                sc.does_copy = *v;
+            }
+            if let Some(v) = min {
+                sc.min = *v;
+            }
+            if let Some(v) = max {
+                sc.max = *v;
+            }
+            if let Some(v) = min_max_space_value {
+                sc.min_max_space_value = *v;
+            }
+            if let Some(v) = copy_factor_y {
+                sc.copy_factor_y = *v;
+            }
+            if let Some(v) = min_value_y {
+                sc.min_value_y = *v;
+            }
+            if let Some(v) = max_value_y {
+                sc.max_value_y = *v;
+            }
+            if let Some(v) = does_copy_y {
+                sc.does_copy_y = *v;
+            }
+            if let Some(v) = min_y {
+                sc.min_y = *v;
+            }
+            if let Some(v) = max_y {
+                sc.max_y = *v;
+            }
             objects.push(Box::new(sc));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::RotationConstraint { name, target, strength, source_space_value, dest_space_value, copy_factor, min_value, max_value, offset, does_copy, min, max, min_max_space_value } => {
+        ObjectSpec::RotationConstraint {
+            name,
+            target,
+            strength,
+            source_space_value,
+            dest_space_value,
+            copy_factor,
+            min_value,
+            max_value,
+            offset,
+            does_copy,
+            min,
+            max,
+            min_max_space_value,
+        } => {
             let mut rc = RotationConstraint::new(name.clone(), parent_id);
             if let Some(target_name) = target {
-                let target_global = *name_to_index.get(target_name).ok_or_else(|| format!("rotation_constraint '{}' references unknown target '{}'", name, target_name))?;
+                let target_global = *name_to_index.get(target_name).ok_or_else(|| {
+                    format!(
+                        "rotation_constraint '{}' references unknown target '{}'",
+                        name, target_name
+                    )
+                })?;
                 rc.target_id = (target_global - artboard_start) as u64;
             }
-            if let Some(s) = strength { rc.strength = *s; }
-            if let Some(v) = source_space_value { rc.source_space_value = *v; }
-            if let Some(v) = dest_space_value { rc.dest_space_value = *v; }
-            if let Some(v) = copy_factor { rc.copy_factor = *v; }
-            if let Some(v) = min_value { rc.min_value = *v; }
-            if let Some(v) = max_value { rc.max_value = *v; }
-            if let Some(v) = offset { rc.offset = *v; }
-            if let Some(v) = does_copy { rc.does_copy = *v; }
-            if let Some(v) = min { rc.min = *v; }
-            if let Some(v) = max { rc.max = *v; }
-            if let Some(v) = min_max_space_value { rc.min_max_space_value = *v; }
+            if let Some(s) = strength {
+                rc.strength = *s;
+            }
+            if let Some(v) = source_space_value {
+                rc.source_space_value = *v;
+            }
+            if let Some(v) = dest_space_value {
+                rc.dest_space_value = *v;
+            }
+            if let Some(v) = copy_factor {
+                rc.copy_factor = *v;
+            }
+            if let Some(v) = min_value {
+                rc.min_value = *v;
+            }
+            if let Some(v) = max_value {
+                rc.max_value = *v;
+            }
+            if let Some(v) = offset {
+                rc.offset = *v;
+            }
+            if let Some(v) = does_copy {
+                rc.does_copy = *v;
+            }
+            if let Some(v) = min {
+                rc.min = *v;
+            }
+            if let Some(v) = max {
+                rc.max = *v;
+            }
+            if let Some(v) = min_max_space_value {
+                rc.min_max_space_value = *v;
+            }
             objects.push(Box::new(rc));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::FollowPathConstraint { name, target, strength, source_space_value, dest_space_value, distance, orient, offset } => {
+        ObjectSpec::FollowPathConstraint {
+            name,
+            target,
+            strength,
+            source_space_value,
+            dest_space_value,
+            distance,
+            orient,
+            offset,
+        } => {
             let mut fpc = FollowPathConstraint::new(name.clone(), parent_id);
             if let Some(target_name) = target {
-                let target_global = *name_to_index.get(target_name).ok_or_else(|| format!("follow_path_constraint '{}' references unknown target '{}'", name, target_name))?;
+                let target_global = *name_to_index.get(target_name).ok_or_else(|| {
+                    format!(
+                        "follow_path_constraint '{}' references unknown target '{}'",
+                        name, target_name
+                    )
+                })?;
                 fpc.target_id = (target_global - artboard_start) as u64;
             }
-            if let Some(s) = strength { fpc.strength = *s; }
-            if let Some(v) = source_space_value { fpc.source_space_value = *v; }
-            if let Some(v) = dest_space_value { fpc.dest_space_value = *v; }
-            if let Some(d) = distance { fpc.distance = *d; }
-            if let Some(o) = orient { fpc.orient = *o; }
-            if let Some(o) = offset { fpc.offset = *o; }
+            if let Some(s) = strength {
+                fpc.strength = *s;
+            }
+            if let Some(v) = source_space_value {
+                fpc.source_space_value = *v;
+            }
+            if let Some(v) = dest_space_value {
+                fpc.dest_space_value = *v;
+            }
+            if let Some(d) = distance {
+                fpc.distance = *d;
+            }
+            if let Some(o) = orient {
+                fpc.orient = *o;
+            }
+            if let Some(o) = offset {
+                fpc.offset = *o;
+            }
             objects.push(Box::new(fpc));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::ClippingShape { name, source, fill_rule, is_visible } => {
+        ObjectSpec::ClippingShape {
+            name,
+            source,
+            fill_rule,
+            is_visible,
+        } => {
             let mut cs = ClippingShape::new(name.clone(), parent_id);
             if let Some(source_name) = source {
-                let source_global = *name_to_index.get(source_name).ok_or_else(|| format!("clipping_shape '{}' references unknown source '{}'", name, source_name))?;
+                let source_global = *name_to_index.get(source_name).ok_or_else(|| {
+                    format!(
+                        "clipping_shape '{}' references unknown source '{}'",
+                        name, source_name
+                    )
+                })?;
                 cs.source_id = (source_global - artboard_start) as u64;
             }
-            if let Some(fr) = fill_rule { cs.fill_rule = parse_fill_rule(fr)?; }
-            if let Some(v) = is_visible { cs.is_visible = *v; }
+            if let Some(fr) = fill_rule {
+                cs.fill_rule = parse_fill_rule(fr)?;
+            }
+            if let Some(v) = is_visible {
+                cs.is_visible = *v;
+            }
             objects.push(Box::new(cs));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::DrawRules { name, draw_target, children } => {
+        ObjectSpec::DrawRules {
+            name,
+            draw_target,
+            children,
+        } => {
             objects.push(Box::new(DrawRules::new(name.clone(), parent_id)));
             name_to_index.insert(name.clone(), object_index);
             if let Some(children) = children {
                 for child in children {
-                    append_object(child, object_index, artboard_start, objects, name_to_index, artboard_name_to_index, current_artboard_name, animation_name_to_index)?;
+                    append_object(
+                        child,
+                        object_index,
+                        artboard_start,
+                        objects,
+                        name_to_index,
+                        artboard_name_to_index,
+                        current_artboard_name,
+                        animation_name_to_index,
+                    )?;
                 }
             }
             if let Some(target_name) = draw_target {
-                let target_global = *name_to_index.get(target_name).ok_or_else(|| format!("draw_rules '{}' references unknown draw_target '{}'", name, target_name))?;
+                let target_global = *name_to_index.get(target_name).ok_or_else(|| {
+                    format!(
+                        "draw_rules '{}' references unknown draw_target '{}'",
+                        name, target_name
+                    )
+                })?;
                 let mut dr = DrawRules::new(name.clone(), parent_id);
                 dr.draw_target_id = (target_global - artboard_start) as u64;
                 objects[object_index] = Box::new(dr);
             }
         }
-        ObjectSpec::DrawTarget { name, drawable, placement_value } => {
+        ObjectSpec::DrawTarget {
+            name,
+            drawable,
+            placement_value,
+        } => {
             let mut dt = DrawTarget::new(name.clone(), parent_id);
             if let Some(drawable_name) = drawable {
-                let drawable_global = *name_to_index.get(drawable_name).ok_or_else(|| format!("draw_target '{}' references unknown drawable '{}'", name, drawable_name))?;
+                let drawable_global = *name_to_index.get(drawable_name).ok_or_else(|| {
+                    format!(
+                        "draw_target '{}' references unknown drawable '{}'",
+                        name, drawable_name
+                    )
+                })?;
                 dt.drawable_id = (drawable_global - artboard_start) as u64;
             }
-            if let Some(pv) = placement_value { dt.placement_value = *pv; }
+            if let Some(pv) = placement_value {
+                dt.placement_value = *pv;
+            }
             objects.push(Box::new(dt));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::Joystick { name, x, y, x_id, y_id, pos_x, pos_y, width, height, origin_x, origin_y, flags, handle_source_id } => {
+        ObjectSpec::Joystick {
+            name,
+            x,
+            y,
+            x_id,
+            y_id,
+            pos_x,
+            pos_y,
+            width,
+            height,
+            origin_x,
+            origin_y,
+            flags,
+            handle_source_id,
+        } => {
             let mut js = Joystick::new(name.clone(), parent_id);
-            if let Some(v) = x { js.x = *v; }
-            if let Some(v) = y { js.y = *v; }
-            if let Some(v) = x_id { js.x_id = *v; }
-            if let Some(v) = y_id { js.y_id = *v; }
-            if let Some(v) = pos_x { js.pos_x = *v; }
-            if let Some(v) = pos_y { js.pos_y = *v; }
-            if let Some(v) = width { js.width = *v; }
-            if let Some(v) = height { js.height = *v; }
-            if let Some(v) = origin_x { js.origin_x = *v; }
-            if let Some(v) = origin_y { js.origin_y = *v; }
-            if let Some(v) = flags { js.flags = *v; }
-            if let Some(v) = handle_source_id { js.handle_source_id = *v; }
+            if let Some(v) = x {
+                js.x = *v;
+            }
+            if let Some(v) = y {
+                js.y = *v;
+            }
+            if let Some(v) = x_id {
+                js.x_id = *v;
+            }
+            if let Some(v) = y_id {
+                js.y_id = *v;
+            }
+            if let Some(v) = pos_x {
+                js.pos_x = *v;
+            }
+            if let Some(v) = pos_y {
+                js.pos_y = *v;
+            }
+            if let Some(v) = width {
+                js.width = *v;
+            }
+            if let Some(v) = height {
+                js.height = *v;
+            }
+            if let Some(v) = origin_x {
+                js.origin_x = *v;
+            }
+            if let Some(v) = origin_y {
+                js.origin_y = *v;
+            }
+            if let Some(v) = flags {
+                js.flags = *v;
+            }
+            if let Some(v) = handle_source_id {
+                js.handle_source_id = *v;
+            }
             objects.push(Box::new(js));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::Text { name, align_value, sizing_value, overflow_value, width, height, origin_x, origin_y, paragraph_spacing, origin_value, children } => {
+        ObjectSpec::Text {
+            name,
+            align_value,
+            sizing_value,
+            overflow_value,
+            width,
+            height,
+            origin_x,
+            origin_y,
+            paragraph_spacing,
+            origin_value,
+            children,
+        } => {
             let mut text = Text::new(name.clone(), parent_id);
-            if let Some(v) = align_value { text.align_value = *v; }
-            if let Some(v) = sizing_value { text.sizing_value = *v; }
-            if let Some(v) = overflow_value { text.overflow_value = *v; }
-            if let Some(v) = width { text.width = *v; }
-            if let Some(v) = height { text.height = *v; }
-            if let Some(v) = origin_x { text.origin_x = *v; }
-            if let Some(v) = origin_y { text.origin_y = *v; }
-            if let Some(v) = paragraph_spacing { text.paragraph_spacing = *v; }
-            if let Some(v) = origin_value { text.origin_value = *v; }
+            if let Some(v) = align_value {
+                text.align_value = *v;
+            }
+            if let Some(v) = sizing_value {
+                text.sizing_value = *v;
+            }
+            if let Some(v) = overflow_value {
+                text.overflow_value = *v;
+            }
+            if let Some(v) = width {
+                text.width = *v;
+            }
+            if let Some(v) = height {
+                text.height = *v;
+            }
+            if let Some(v) = origin_x {
+                text.origin_x = *v;
+            }
+            if let Some(v) = origin_y {
+                text.origin_y = *v;
+            }
+            if let Some(v) = paragraph_spacing {
+                text.paragraph_spacing = *v;
+            }
+            if let Some(v) = origin_value {
+                text.origin_value = *v;
+            }
             objects.push(Box::new(text));
             name_to_index.insert(name.clone(), object_index);
             if let Some(children) = children {
                 for child in children {
-                    append_object(child, object_index, artboard_start, objects, name_to_index, artboard_name_to_index, current_artboard_name, animation_name_to_index)?;
+                    append_object(
+                        child,
+                        object_index,
+                        artboard_start,
+                        objects,
+                        name_to_index,
+                        artboard_name_to_index,
+                        current_artboard_name,
+                        animation_name_to_index,
+                    )?;
                 }
             }
         }
-        ObjectSpec::TextStyle { name, font_size, line_height, letter_spacing, font_asset_id, children } => {
+        ObjectSpec::TextStyle {
+            name,
+            font_size,
+            line_height,
+            letter_spacing,
+            font_asset_id,
+            children,
+        } => {
             let mut style = TextStyle::new(name.clone(), parent_id);
-            if let Some(v) = font_size { style.font_size = *v; }
-            if let Some(v) = line_height { style.line_height = *v; }
-            if let Some(v) = letter_spacing { style.letter_spacing = *v; }
-            if let Some(v) = font_asset_id { style.font_asset_id = *v; }
+            if let Some(v) = font_size {
+                style.font_size = *v;
+            }
+            if let Some(v) = line_height {
+                style.line_height = *v;
+            }
+            if let Some(v) = letter_spacing {
+                style.letter_spacing = *v;
+            }
+            if let Some(v) = font_asset_id {
+                style.font_asset_id = *v;
+            }
             objects.push(Box::new(style));
             name_to_index.insert(name.clone(), object_index);
             let child_parent_id = object_index
@@ -980,88 +1421,261 @@ pub(crate) fn append_object(
                 }
             }
         }
-        ObjectSpec::TextValueRun { name, text, style_id } => {
+        ObjectSpec::TextValueRun {
+            name,
+            text,
+            style_id,
+        } => {
             let mut run = TextValueRun::new(name.clone(), parent_id, text.clone());
-            if let Some(v) = style_id { run.style_id = *v; }
+            if let Some(v) = style_id {
+                run.style_id = *v;
+            }
             objects.push(Box::new(run));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::ImageAsset { name, asset_id, cdn_base_url } => {
+        ObjectSpec::ImageAsset {
+            name,
+            asset_id,
+            cdn_base_url,
+        } => {
             let mut asset = ImageAsset::new(name.clone());
-            if let Some(v) = asset_id { asset.asset_id = *v; }
-            if let Some(v) = cdn_base_url { asset.cdn_base_url = v.clone(); }
+            if let Some(v) = asset_id {
+                asset.asset_id = *v;
+            }
+            if let Some(v) = cdn_base_url {
+                asset.cdn_base_url = v.clone();
+            }
             objects.push(Box::new(asset));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::FontAsset { name, asset_id, cdn_base_url } => {
+        ObjectSpec::FontAsset {
+            name,
+            asset_id,
+            cdn_base_url,
+        } => {
             let mut asset = FontAsset::new(name.clone());
-            if let Some(v) = asset_id { asset.asset_id = *v; }
-            if let Some(v) = cdn_base_url { asset.cdn_base_url = v.clone(); }
+            if let Some(v) = asset_id {
+                asset.asset_id = *v;
+            }
+            if let Some(v) = cdn_base_url {
+                asset.cdn_base_url = v.clone();
+            }
             objects.push(Box::new(asset));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::AudioAsset { name, asset_id, cdn_base_url } => {
+        ObjectSpec::AudioAsset {
+            name,
+            asset_id,
+            cdn_base_url,
+        } => {
             let mut asset = AudioAsset::new(name.clone());
-            if let Some(v) = asset_id { asset.asset_id = *v; }
-            if let Some(v) = cdn_base_url { asset.cdn_base_url = v.clone(); }
+            if let Some(v) = asset_id {
+                asset.asset_id = *v;
+            }
+            if let Some(v) = cdn_base_url {
+                asset.cdn_base_url = v.clone();
+            }
             objects.push(Box::new(asset));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::LayoutComponent { name, clip, width, height, style_id, fractional_width, fractional_height, children } => {
+        ObjectSpec::LayoutComponent {
+            name,
+            clip,
+            width,
+            height,
+            style_id,
+            fractional_width,
+            fractional_height,
+            children,
+        } => {
             let mut lc = LayoutComponent::new(name.clone(), parent_id);
-            if let Some(v) = clip { lc.clip = *v; }
-            if let Some(v) = width { lc.width = *v; }
-            if let Some(v) = height { lc.height = *v; }
-            if let Some(v) = style_id { lc.style_id = *v; }
-            if let Some(v) = fractional_width { lc.fractional_width = *v; }
-            if let Some(v) = fractional_height { lc.fractional_height = *v; }
+            if let Some(v) = clip {
+                lc.clip = *v;
+            }
+            if let Some(v) = width {
+                lc.width = *v;
+            }
+            if let Some(v) = height {
+                lc.height = *v;
+            }
+            if let Some(v) = style_id {
+                lc.style_id = *v;
+            }
+            if let Some(v) = fractional_width {
+                lc.fractional_width = *v;
+            }
+            if let Some(v) = fractional_height {
+                lc.fractional_height = *v;
+            }
             objects.push(Box::new(lc));
             name_to_index.insert(name.clone(), object_index);
             if let Some(children) = children {
                 for child in children {
-                    append_object(child, object_index, artboard_start, objects, name_to_index, artboard_name_to_index, current_artboard_name, animation_name_to_index)?;
+                    append_object(
+                        child,
+                        object_index,
+                        artboard_start,
+                        objects,
+                        name_to_index,
+                        artboard_name_to_index,
+                        current_artboard_name,
+                        animation_name_to_index,
+                    )?;
                 }
             }
         }
-        ObjectSpec::LayoutComponentStyle { name, gap_horizontal, gap_vertical, max_width, max_height, min_width, min_height, border_left, border_right, border_top, border_bottom, margin_left, margin_right, margin_top, margin_bottom, padding_left, padding_right, padding_top, padding_bottom, position_left, position_right, position_top, position_bottom, flex_direction, flex_wrap, align_items, align_content, justify_content, display, position_type, overflow, intrinsically_sized, width_units, height_units, flex_grow, flex_shrink, flex_basis, aspect_ratio } => {
+        ObjectSpec::LayoutComponentStyle {
+            name,
+            gap_horizontal,
+            gap_vertical,
+            max_width,
+            max_height,
+            min_width,
+            min_height,
+            border_left,
+            border_right,
+            border_top,
+            border_bottom,
+            margin_left,
+            margin_right,
+            margin_top,
+            margin_bottom,
+            padding_left,
+            padding_right,
+            padding_top,
+            padding_bottom,
+            position_left,
+            position_right,
+            position_top,
+            position_bottom,
+            flex_direction,
+            flex_wrap,
+            align_items,
+            align_content,
+            justify_content,
+            display,
+            position_type,
+            overflow,
+            intrinsically_sized,
+            width_units,
+            height_units,
+            flex_grow,
+            flex_shrink,
+            flex_basis,
+            aspect_ratio,
+        } => {
             let mut style = LayoutComponentStyle::new(name.clone(), parent_id);
-            if let Some(v) = gap_horizontal { style.gap_horizontal = *v; }
-            if let Some(v) = gap_vertical { style.gap_vertical = *v; }
-            if let Some(v) = max_width { style.max_width = *v; }
-            if let Some(v) = max_height { style.max_height = *v; }
-            if let Some(v) = min_width { style.min_width = *v; }
-            if let Some(v) = min_height { style.min_height = *v; }
-            if let Some(v) = border_left { style.border_left = *v; }
-            if let Some(v) = border_right { style.border_right = *v; }
-            if let Some(v) = border_top { style.border_top = *v; }
-            if let Some(v) = border_bottom { style.border_bottom = *v; }
-            if let Some(v) = margin_left { style.margin_left = *v; }
-            if let Some(v) = margin_right { style.margin_right = *v; }
-            if let Some(v) = margin_top { style.margin_top = *v; }
-            if let Some(v) = margin_bottom { style.margin_bottom = *v; }
-            if let Some(v) = padding_left { style.padding_left = *v; }
-            if let Some(v) = padding_right { style.padding_right = *v; }
-            if let Some(v) = padding_top { style.padding_top = *v; }
-            if let Some(v) = padding_bottom { style.padding_bottom = *v; }
-            if let Some(v) = position_left { style.position_left = *v; }
-            if let Some(v) = position_right { style.position_right = *v; }
-            if let Some(v) = position_top { style.position_top = *v; }
-            if let Some(v) = position_bottom { style.position_bottom = *v; }
-            if let Some(v) = flex_direction { style.flex_direction = *v; }
-            if let Some(v) = flex_wrap { style.flex_wrap = *v; }
-            if let Some(v) = align_items { style.align_items = *v; }
-            if let Some(v) = align_content { style.align_content = *v; }
-            if let Some(v) = justify_content { style.justify_content = *v; }
-            if let Some(v) = display { style.display = *v; }
-            if let Some(v) = position_type { style.position_type = *v; }
-            if let Some(v) = overflow { style.overflow = *v; }
-            if let Some(v) = intrinsically_sized { style.intrinsically_sized = *v; }
-            if let Some(v) = width_units { style.width_units = *v; }
-            if let Some(v) = height_units { style.height_units = *v; }
-            if let Some(v) = flex_grow { style.flex_grow = *v; }
-            if let Some(v) = flex_shrink { style.flex_shrink = *v; }
-            if let Some(v) = flex_basis { style.flex_basis = *v; }
-            if let Some(v) = aspect_ratio { style.aspect_ratio = *v; }
+            if let Some(v) = gap_horizontal {
+                style.gap_horizontal = *v;
+            }
+            if let Some(v) = gap_vertical {
+                style.gap_vertical = *v;
+            }
+            if let Some(v) = max_width {
+                style.max_width = *v;
+            }
+            if let Some(v) = max_height {
+                style.max_height = *v;
+            }
+            if let Some(v) = min_width {
+                style.min_width = *v;
+            }
+            if let Some(v) = min_height {
+                style.min_height = *v;
+            }
+            if let Some(v) = border_left {
+                style.border_left = *v;
+            }
+            if let Some(v) = border_right {
+                style.border_right = *v;
+            }
+            if let Some(v) = border_top {
+                style.border_top = *v;
+            }
+            if let Some(v) = border_bottom {
+                style.border_bottom = *v;
+            }
+            if let Some(v) = margin_left {
+                style.margin_left = *v;
+            }
+            if let Some(v) = margin_right {
+                style.margin_right = *v;
+            }
+            if let Some(v) = margin_top {
+                style.margin_top = *v;
+            }
+            if let Some(v) = margin_bottom {
+                style.margin_bottom = *v;
+            }
+            if let Some(v) = padding_left {
+                style.padding_left = *v;
+            }
+            if let Some(v) = padding_right {
+                style.padding_right = *v;
+            }
+            if let Some(v) = padding_top {
+                style.padding_top = *v;
+            }
+            if let Some(v) = padding_bottom {
+                style.padding_bottom = *v;
+            }
+            if let Some(v) = position_left {
+                style.position_left = *v;
+            }
+            if let Some(v) = position_right {
+                style.position_right = *v;
+            }
+            if let Some(v) = position_top {
+                style.position_top = *v;
+            }
+            if let Some(v) = position_bottom {
+                style.position_bottom = *v;
+            }
+            if let Some(v) = flex_direction {
+                style.flex_direction = *v;
+            }
+            if let Some(v) = flex_wrap {
+                style.flex_wrap = *v;
+            }
+            if let Some(v) = align_items {
+                style.align_items = *v;
+            }
+            if let Some(v) = align_content {
+                style.align_content = *v;
+            }
+            if let Some(v) = justify_content {
+                style.justify_content = *v;
+            }
+            if let Some(v) = display {
+                style.display = *v;
+            }
+            if let Some(v) = position_type {
+                style.position_type = *v;
+            }
+            if let Some(v) = overflow {
+                style.overflow = *v;
+            }
+            if let Some(v) = intrinsically_sized {
+                style.intrinsically_sized = *v;
+            }
+            if let Some(v) = width_units {
+                style.width_units = *v;
+            }
+            if let Some(v) = height_units {
+                style.height_units = *v;
+            }
+            if let Some(v) = flex_grow {
+                style.flex_grow = *v;
+            }
+            if let Some(v) = flex_shrink {
+                style.flex_shrink = *v;
+            }
+            if let Some(v) = flex_basis {
+                style.flex_basis = *v;
+            }
+            if let Some(v) = aspect_ratio {
+                style.aspect_ratio = *v;
+            }
             objects.push(Box::new(style));
             name_to_index.insert(name.clone(), object_index);
         }
@@ -1071,102 +1685,252 @@ pub(crate) fn append_object(
             name_to_index.insert(name.clone(), object_index);
             if let Some(children) = children {
                 for child in children {
-                    append_object(child, object_index, artboard_start, objects, name_to_index, artboard_name_to_index, current_artboard_name, animation_name_to_index)?;
+                    append_object(
+                        child,
+                        object_index,
+                        artboard_start,
+                        objects,
+                        name_to_index,
+                        artboard_name_to_index,
+                        current_artboard_name,
+                        animation_name_to_index,
+                    )?;
                 }
             }
         }
-        ObjectSpec::ViewModelProperty { name, property_type_value } => {
-            let vmp = ViewModelProperty::new(name.clone(), parent_id, property_type_value.unwrap_or(0));
+        ObjectSpec::ViewModelProperty {
+            name,
+            property_type_value,
+        } => {
+            let vmp =
+                ViewModelProperty::new(name.clone(), parent_id, property_type_value.unwrap_or(0));
             objects.push(Box::new(vmp));
             name_to_index.insert(name.clone(), object_index);
         }
-        ObjectSpec::DataBind { property_key, flags, converter_id } => {
+        ObjectSpec::DataBind {
+            property_key,
+            flags,
+            converter_id,
+        } => {
             let mut db = DataBind::new(*property_key, *flags);
-            if let Some(v) = converter_id { db.converter_id = *v; }
+            if let Some(v) = converter_id {
+                db.converter_id = *v;
+            }
             objects.push(Box::new(db));
         }
         ObjectSpec::ViewModelInstance { view_model_id } => {
             objects.push(Box::new(ViewModelInstance {
-                view_model_id: required_u64_field(*view_model_id, "view_model_instance", "view_model_id")?,
+                view_model_id: required_u64_field(
+                    *view_model_id,
+                    "view_model_instance",
+                    "view_model_id",
+                )?,
             }));
         }
-        ObjectSpec::ViewModelInstanceValue { view_model_property_id } => {
+        ObjectSpec::ViewModelInstanceValue {
+            view_model_property_id,
+        } => {
             objects.push(Box::new(ViewModelInstanceValue {
-                view_model_property_id: required_u64_field(*view_model_property_id, "view_model_instance_value", "view_model_property_id")?,
+                view_model_property_id: required_u64_field(
+                    *view_model_property_id,
+                    "view_model_instance_value",
+                    "view_model_property_id",
+                )?,
             }));
         }
-        ObjectSpec::ViewModelInstanceColor { view_model_property_id, value } => {
+        ObjectSpec::ViewModelInstanceColor {
+            view_model_property_id,
+            value,
+        } => {
             let color = parse_color(value)?;
             objects.push(Box::new(ViewModelInstanceColor {
-                view_model_property_id: required_u64_field(*view_model_property_id, "view_model_instance_color", "view_model_property_id")?,
+                view_model_property_id: required_u64_field(
+                    *view_model_property_id,
+                    "view_model_instance_color",
+                    "view_model_property_id",
+                )?,
                 property_value: color,
             }));
         }
-        ObjectSpec::ViewModelInstanceString { view_model_property_id, value } => {
+        ObjectSpec::ViewModelInstanceString {
+            view_model_property_id,
+            value,
+        } => {
             objects.push(Box::new(ViewModelInstanceString {
-                view_model_property_id: required_u64_field(*view_model_property_id, "view_model_instance_string", "view_model_property_id")?,
+                view_model_property_id: required_u64_field(
+                    *view_model_property_id,
+                    "view_model_instance_string",
+                    "view_model_property_id",
+                )?,
                 property_value: value.clone(),
             }));
         }
-        ObjectSpec::ViewModelInstanceNumber { view_model_property_id, value } => {
+        ObjectSpec::ViewModelInstanceNumber {
+            view_model_property_id,
+            value,
+        } => {
             objects.push(Box::new(ViewModelInstanceNumber {
-                view_model_property_id: required_u64_field(*view_model_property_id, "view_model_instance_number", "view_model_property_id")?,
+                view_model_property_id: required_u64_field(
+                    *view_model_property_id,
+                    "view_model_instance_number",
+                    "view_model_property_id",
+                )?,
                 property_value: *value,
             }));
         }
-        ObjectSpec::ViewModelInstanceBoolean { view_model_property_id, value } => {
+        ObjectSpec::ViewModelInstanceBoolean {
+            view_model_property_id,
+            value,
+        } => {
             objects.push(Box::new(ViewModelInstanceBoolean {
-                view_model_property_id: required_u64_field(*view_model_property_id, "view_model_instance_boolean", "view_model_property_id")?,
+                view_model_property_id: required_u64_field(
+                    *view_model_property_id,
+                    "view_model_instance_boolean",
+                    "view_model_property_id",
+                )?,
                 property_value: *value,
             }));
         }
-        ObjectSpec::ViewModelInstanceEnum { view_model_property_id, value } => {
+        ObjectSpec::ViewModelInstanceEnum {
+            view_model_property_id,
+            value,
+        } => {
             objects.push(Box::new(ViewModelInstanceEnum {
-                view_model_property_id: required_u64_field(*view_model_property_id, "view_model_instance_enum", "view_model_property_id")?,
+                view_model_property_id: required_u64_field(
+                    *view_model_property_id,
+                    "view_model_instance_enum",
+                    "view_model_property_id",
+                )?,
                 property_value: required_u64_field(*value, "view_model_instance_enum", "value")?,
             }));
         }
         ObjectSpec::ViewModelInstanceList => {
             objects.push(Box::new(ViewModelInstanceList));
         }
-        ObjectSpec::ViewModelInstanceListItem { view_model_id, view_model_instance_id } => {
+        ObjectSpec::ViewModelInstanceListItem {
+            view_model_id,
+            view_model_instance_id,
+        } => {
             objects.push(Box::new(ViewModelInstanceListItem {
-                view_model_id: required_u64_field(*view_model_id, "view_model_instance_list_item", "view_model_id")?,
-                view_model_instance_id: required_u64_field(*view_model_instance_id, "view_model_instance_list_item", "view_model_instance_id")?,
+                view_model_id: required_u64_field(
+                    *view_model_id,
+                    "view_model_instance_list_item",
+                    "view_model_id",
+                )?,
+                view_model_instance_id: required_u64_field(
+                    *view_model_instance_id,
+                    "view_model_instance_list_item",
+                    "view_model_instance_id",
+                )?,
             }));
         }
-        ObjectSpec::ViewModelInstanceViewModel { view_model_property_id, value } => {
+        ObjectSpec::ViewModelInstanceViewModel {
+            view_model_property_id,
+            value,
+        } => {
             objects.push(Box::new(ViewModelInstanceViewModel {
-                view_model_property_id: required_u64_field(*view_model_property_id, "view_model_instance_view_model", "view_model_property_id")?,
-                property_value: required_u64_field(*value, "view_model_instance_view_model", "value")?,
+                view_model_property_id: required_u64_field(
+                    *view_model_property_id,
+                    "view_model_instance_view_model",
+                    "view_model_property_id",
+                )?,
+                property_value: required_u64_field(
+                    *value,
+                    "view_model_instance_view_model",
+                    "value",
+                )?,
             }));
         }
-        ObjectSpec::TextModifierRange { units_value, type_value, mode_value, modify_from, modify_to, strength, clamp, falloff_from, falloff_to, offset, run_id } => {
+        ObjectSpec::TextModifierRange {
+            units_value,
+            type_value,
+            mode_value,
+            modify_from,
+            modify_to,
+            strength,
+            clamp,
+            falloff_from,
+            falloff_to,
+            offset,
+            run_id,
+        } => {
             let mut r = TextModifierRange::new(parent_id);
-            if let Some(v) = units_value { r.units_value = *v; }
-            if let Some(v) = type_value { r.type_value = *v; }
-            if let Some(v) = mode_value { r.mode_value = *v; }
-            if let Some(v) = modify_from { r.modify_from = *v; }
-            if let Some(v) = modify_to { r.modify_to = *v; }
-            if let Some(v) = strength { r.strength = *v; }
-            if let Some(v) = clamp { r.clamp = *v; }
-            if let Some(v) = falloff_from { r.falloff_from = *v; }
-            if let Some(v) = falloff_to { r.falloff_to = *v; }
-            if let Some(v) = offset { r.offset = *v; }
-            if let Some(v) = run_id { r.run_id = *v; }
+            if let Some(v) = units_value {
+                r.units_value = *v;
+            }
+            if let Some(v) = type_value {
+                r.type_value = *v;
+            }
+            if let Some(v) = mode_value {
+                r.mode_value = *v;
+            }
+            if let Some(v) = modify_from {
+                r.modify_from = *v;
+            }
+            if let Some(v) = modify_to {
+                r.modify_to = *v;
+            }
+            if let Some(v) = strength {
+                r.strength = *v;
+            }
+            if let Some(v) = clamp {
+                r.clamp = *v;
+            }
+            if let Some(v) = falloff_from {
+                r.falloff_from = *v;
+            }
+            if let Some(v) = falloff_to {
+                r.falloff_to = *v;
+            }
+            if let Some(v) = offset {
+                r.offset = *v;
+            }
+            if let Some(v) = run_id {
+                r.run_id = *v;
+            }
             objects.push(Box::new(r));
         }
-        ObjectSpec::TextModifierGroup { name, modifier_flags, origin_x, origin_y, opacity, x, y, rotation, scale_x, scale_y, children } => {
+        ObjectSpec::TextModifierGroup {
+            name,
+            modifier_flags,
+            origin_x,
+            origin_y,
+            opacity,
+            x,
+            y,
+            rotation,
+            scale_x,
+            scale_y,
+            children,
+        } => {
             let mut g = TextModifierGroup::new(name.clone(), parent_id);
-            if let Some(v) = modifier_flags { g.modifier_flags = *v; }
-            if let Some(v) = origin_x { g.origin_x = *v; }
-            if let Some(v) = origin_y { g.origin_y = *v; }
-            if let Some(v) = opacity { g.opacity = *v; }
-            if let Some(v) = x { g.x = *v; }
-            if let Some(v) = y { g.y = *v; }
-            if let Some(v) = rotation { g.rotation = *v; }
-            if let Some(v) = scale_x { g.scale_x = *v; }
-            if let Some(v) = scale_y { g.scale_y = *v; }
+            if let Some(v) = modifier_flags {
+                g.modifier_flags = *v;
+            }
+            if let Some(v) = origin_x {
+                g.origin_x = *v;
+            }
+            if let Some(v) = origin_y {
+                g.origin_y = *v;
+            }
+            if let Some(v) = opacity {
+                g.opacity = *v;
+            }
+            if let Some(v) = x {
+                g.x = *v;
+            }
+            if let Some(v) = y {
+                g.y = *v;
+            }
+            if let Some(v) = rotation {
+                g.rotation = *v;
+            }
+            if let Some(v) = scale_x {
+                g.scale_x = *v;
+            }
+            if let Some(v) = scale_y {
+                g.scale_y = *v;
+            }
             objects.push(Box::new(g));
             name_to_index.insert(name.clone(), object_index);
             let child_parent_id = object_index
@@ -1179,7 +1943,10 @@ pub(crate) fn append_object(
                 }
             }
         }
-        ObjectSpec::TextVariationModifier { axis_tag, axis_value } => {
+        ObjectSpec::TextVariationModifier {
+            axis_tag,
+            axis_value,
+        } => {
             objects.push(Box::new(TextVariationModifier {
                 parent_id,
                 axis_tag: axis_tag.unwrap_or(0),
@@ -1220,23 +1987,58 @@ pub(crate) fn append_text_modifier_group_child(
 ) {
     match spec {
         TextModifierGroupChildSpec::TextModifierRange {
-            units_value, type_value, mode_value, modify_from, modify_to, strength, clamp, falloff_from, falloff_to, offset, run_id,
+            units_value,
+            type_value,
+            mode_value,
+            modify_from,
+            modify_to,
+            strength,
+            clamp,
+            falloff_from,
+            falloff_to,
+            offset,
+            run_id,
         } => {
             let mut range = TextModifierRange::new(parent_id);
-            if let Some(v) = units_value { range.units_value = *v; }
-            if let Some(v) = type_value { range.type_value = *v; }
-            if let Some(v) = mode_value { range.mode_value = *v; }
-            if let Some(v) = modify_from { range.modify_from = *v; }
-            if let Some(v) = modify_to { range.modify_to = *v; }
-            if let Some(v) = strength { range.strength = *v; }
-            if let Some(v) = clamp { range.clamp = *v; }
-            if let Some(v) = falloff_from { range.falloff_from = *v; }
-            if let Some(v) = falloff_to { range.falloff_to = *v; }
-            if let Some(v) = offset { range.offset = *v; }
-            if let Some(v) = run_id { range.run_id = *v; }
+            if let Some(v) = units_value {
+                range.units_value = *v;
+            }
+            if let Some(v) = type_value {
+                range.type_value = *v;
+            }
+            if let Some(v) = mode_value {
+                range.mode_value = *v;
+            }
+            if let Some(v) = modify_from {
+                range.modify_from = *v;
+            }
+            if let Some(v) = modify_to {
+                range.modify_to = *v;
+            }
+            if let Some(v) = strength {
+                range.strength = *v;
+            }
+            if let Some(v) = clamp {
+                range.clamp = *v;
+            }
+            if let Some(v) = falloff_from {
+                range.falloff_from = *v;
+            }
+            if let Some(v) = falloff_to {
+                range.falloff_to = *v;
+            }
+            if let Some(v) = offset {
+                range.offset = *v;
+            }
+            if let Some(v) = run_id {
+                range.run_id = *v;
+            }
             objects.push(Box::new(range));
         }
-        TextModifierGroupChildSpec::TextVariationModifier { axis_tag, axis_value } => {
+        TextModifierGroupChildSpec::TextVariationModifier {
+            axis_tag,
+            axis_value,
+        } => {
             objects.push(Box::new(TextVariationModifier {
                 parent_id,
                 axis_tag: axis_tag.unwrap_or(0),

--- a/src/builder/scene.rs
+++ b/src/builder/scene.rs
@@ -14,11 +14,11 @@ use super::validation::validate_scene_spec;
 // Re-export spec types for public API and test visibility via `use super::*`.
 #[allow(unused_imports)]
 pub use super::spec::{
-    ArtboardSpec, AnimationSpec, BlendState1DChildSpec, BlendStateChildSpec,
+    AnimationSpec, ArtboardSpec, BlendState1DChildSpec, BlendStateChildSpec,
     BlendStateDirectChildSpec, ConditionSpec, InputSpec, InterpolatorSpec, KeyframeGroupSpec,
     KeyframeSpec, LayerSpec, ListenerActionSpec, ObjectSpec, StateMachineListenerSpec,
-    StateMachineSpec, StateSpec, TextModifierGroupChildSpec, TextStyleChildSpec, TransitionChildSpec,
-    TransitionSpec,
+    StateMachineSpec, StateSpec, TextModifierGroupChildSpec, TextStyleChildSpec,
+    TransitionChildSpec, TransitionSpec,
 };
 
 // Re-export parser functions for test visibility via `use super::*`.

--- a/src/builder/scene.rs
+++ b/src/builder/scene.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use serde::Serialize;
+
 use crate::objects::artboard::{Artboard, Backboard};
 use crate::objects::core::RiveObject;
 
@@ -42,7 +44,7 @@ const ARTBOARD_PRESET_BANNER_HEIGHT: f32 = 90.0;
 const ARTBOARD_PRESET_STORY_WIDTH: f32 = 1080.0;
 const ARTBOARD_PRESET_STORY_HEIGHT: f32 = 1920.0;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Serialize)]
 pub struct ArtboardPreset {
     pub name: &'static str,
     pub width: f32,

--- a/src/builder/state_machines.rs
+++ b/src/builder/state_machines.rs
@@ -3,15 +3,14 @@ use std::collections::HashMap;
 use crate::objects::core::RiveObject;
 use crate::objects::state_machine::{
     AnimationState, AnyState, BlendAnimation, BlendAnimation1D, BlendAnimationDirect, BlendState,
-    BlendState1D, BlendState1DInput, BlendStateDirect, EntryState, ExitState,
-    ListenerBoolChange, ListenerNumberChange, ListenerTriggerChange, StateMachine,
-    StateMachineBool, StateMachineLayer, StateMachineListener, StateMachineNumber,
-    StateMachineTrigger, StateTransition, TransitionBoolCondition, TransitionInputCondition,
-    TransitionNumberCondition, TransitionPropertyComparator, TransitionTriggerCondition,
-    TransitionValueBooleanComparator, TransitionValueColorComparator, TransitionValueCondition,
-    TransitionValueEnumComparator, TransitionValueNumberComparator,
-    TransitionValueStringComparator, TransitionValueTriggerComparator,
-    TransitionViewModelCondition,
+    BlendState1D, BlendState1DInput, BlendStateDirect, EntryState, ExitState, ListenerBoolChange,
+    ListenerNumberChange, ListenerTriggerChange, StateMachine, StateMachineBool, StateMachineLayer,
+    StateMachineListener, StateMachineNumber, StateMachineTrigger, StateTransition,
+    TransitionBoolCondition, TransitionInputCondition, TransitionNumberCondition,
+    TransitionPropertyComparator, TransitionTriggerCondition, TransitionValueBooleanComparator,
+    TransitionValueColorComparator, TransitionValueCondition, TransitionValueEnumComparator,
+    TransitionValueNumberComparator, TransitionValueStringComparator,
+    TransitionValueTriggerComparator, TransitionViewModelCondition,
 };
 
 use super::parsers::{input_is_trigger, json_value_to_f32, parse_color, parse_condition_op};
@@ -82,12 +81,13 @@ pub(crate) fn build_state_machines(
                     for action in actions {
                         match action {
                             ListenerActionSpec::BoolChange { input, value } => {
-                                let input_index = *input_name_to_index.get(input).ok_or_else(|| {
-                                    format!(
-                                        "unknown input referenced in listener action: '{}'",
-                                        input
-                                    )
-                                })?;
+                                let input_index =
+                                    *input_name_to_index.get(input).ok_or_else(|| {
+                                        format!(
+                                            "unknown input referenced in listener action: '{}'",
+                                            input
+                                        )
+                                    })?;
                                 let bool_value = match value {
                                     Some(serde_json::Value::Bool(v)) => {
                                         if *v { 1 } else { 0 }
@@ -114,23 +114,25 @@ pub(crate) fn build_state_machines(
                                 }));
                             }
                             ListenerActionSpec::TriggerChange { input } => {
-                                let input_index = *input_name_to_index.get(input).ok_or_else(|| {
-                                    format!(
-                                        "unknown input referenced in listener action: '{}'",
-                                        input
-                                    )
-                                })?;
+                                let input_index =
+                                    *input_name_to_index.get(input).ok_or_else(|| {
+                                        format!(
+                                            "unknown input referenced in listener action: '{}'",
+                                            input
+                                        )
+                                    })?;
                                 objects.push(Box::new(ListenerTriggerChange {
                                     input_id: input_index as u64,
                                 }));
                             }
                             ListenerActionSpec::NumberChange { input, value } => {
-                                let input_index = *input_name_to_index.get(input).ok_or_else(|| {
-                                    format!(
-                                        "unknown input referenced in listener action: '{}'",
-                                        input
-                                    )
-                                })?;
+                                let input_index =
+                                    *input_name_to_index.get(input).ok_or_else(|| {
+                                        format!(
+                                            "unknown input referenced in listener action: '{}'",
+                                            input
+                                        )
+                                    })?;
                                 let number_value = match value {
                                     Some(v) => json_value_to_f32(v).ok_or_else(|| {
                                         format!(
@@ -223,14 +225,13 @@ pub(crate) fn build_state_machines(
                         if transition.from != user_idx {
                             continue;
                         }
-                        let state_to_id =
-                            *user_to_final.get(transition.to).ok_or_else(|| {
-                                format!(
-                                    "transition target index {} out of bounds (layer has {} states)",
-                                    transition.to,
-                                    user_to_final.len()
-                                )
-                            })? as u64;
+                        let state_to_id = *user_to_final.get(transition.to).ok_or_else(|| {
+                            format!(
+                                "transition target index {} out of bounds (layer has {} states)",
+                                transition.to,
+                                user_to_final.len()
+                            )
+                        })? as u64;
                         let mut state_transition = StateTransition::new(state_to_id);
                         if let Some(duration) = transition.duration {
                             state_transition.duration = duration;
@@ -266,11 +267,9 @@ pub(crate) fn build_state_machines(
                                                         condition.input
                                                     )
                                                 })?;
-                                            objects.push(Box::new(
-                                                TransitionNumberCondition::new(
-                                                    input_id, op, value,
-                                                ),
-                                            ));
+                                            objects.push(Box::new(TransitionNumberCondition::new(
+                                                input_id, op, value,
+                                            )));
                                         }
                                         Some(serde_json::Value::Bool(v)) => {
                                             let bool_op = if condition.op.is_some() {
@@ -284,20 +283,16 @@ pub(crate) fn build_state_machines(
                                             } else {
                                                 1 // notEqual: true when input is false
                                             };
-                                            objects.push(Box::new(
-                                                TransitionBoolCondition::new(
-                                                    input_id, bool_op,
-                                                ),
-                                            ));
+                                            objects.push(Box::new(TransitionBoolCondition::new(
+                                                input_id, bool_op,
+                                            )));
                                         }
                                         _ => {
                                             if condition.op.is_some() {
-                                                objects.push(Box::new(
-                                                    TransitionValueCondition {
-                                                        input_id,
-                                                        op,
-                                                    },
-                                                ));
+                                                objects.push(Box::new(TransitionValueCondition {
+                                                    input_id,
+                                                    op,
+                                                }));
                                             } else if input_is_trigger(
                                                 &condition.input,
                                                 state_machine.inputs.as_ref(),
@@ -306,9 +301,9 @@ pub(crate) fn build_state_machines(
                                                     TransitionTriggerCondition { input_id },
                                                 ));
                                             } else {
-                                                objects.push(Box::new(
-                                                    TransitionInputCondition { input_id },
-                                                ));
+                                                objects.push(Box::new(TransitionInputCondition {
+                                                    input_id,
+                                                }));
                                             }
                                         }
                                     }

--- a/src/builder/validation.rs
+++ b/src/builder/validation.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::objects::core::{is_bool_property, property_backing_type, type_keys, BackingType};
+use crate::objects::core::{BackingType, is_bool_property, property_backing_type, type_keys};
 
 use super::parsers::{
     condition_op_is_valid, interpolation_type_from_name, json_value_to_color, json_value_to_f32,
@@ -10,9 +10,9 @@ use super::parsers::{
 };
 use super::scene::resolve_artboard_dimensions;
 use super::spec::{
-    ArtboardSpec, BlendState1DChildSpec, BlendStateChildSpec, BlendStateDirectChildSpec,
-    InputSpec, ListenerActionSpec, ObjectSpec, ParentKind, SceneSpec, StateSpec,
-    TextModifierGroupChildSpec, TextStyleChildSpec, TransitionChildSpec, SCENE_FORMAT_VERSION,
+    ArtboardSpec, BlendState1DChildSpec, BlendStateChildSpec, BlendStateDirectChildSpec, InputSpec,
+    ListenerActionSpec, ObjectSpec, ParentKind, SCENE_FORMAT_VERSION, SceneSpec, StateSpec,
+    TextModifierGroupChildSpec, TextStyleChildSpec, TransitionChildSpec,
 };
 
 pub(crate) fn validate_scene_spec(spec: &SceneSpec) -> Result<(), String> {
@@ -1065,7 +1065,10 @@ pub(crate) fn validate_object_spec(
     Ok(())
 }
 
-pub(crate) fn collect_object_type_key(spec: &ObjectSpec, object_type_keys: &mut HashMap<String, u16>) {
+pub(crate) fn collect_object_type_key(
+    spec: &ObjectSpec,
+    object_type_keys: &mut HashMap<String, u16>,
+) {
     match spec {
         ObjectSpec::Shape { name, children, .. } => {
             object_type_keys.insert(name.clone(), type_keys::SHAPE);
@@ -1355,7 +1358,9 @@ pub(crate) fn collect_nested_artboard_refs(children: &[ObjectSpec]) -> Vec<Strin
     refs
 }
 
-pub(crate) fn detect_artboard_cycles(artboard_deps: &HashMap<String, Vec<String>>) -> Result<(), String> {
+pub(crate) fn detect_artboard_cycles(
+    artboard_deps: &HashMap<String, Vec<String>>,
+) -> Result<(), String> {
     for start in artboard_deps.keys() {
         let mut visited: HashSet<&str> = HashSet::new();
         let mut stack = vec![start.as_str()];

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,9 @@ pub struct Cli {
     #[arg(long, help = "List available artboard size presets")]
     pub list_presets: bool,
 
+    #[arg(long, help = "Output as JSON")]
+    pub json: bool,
+
     #[cfg(feature = "mcp")]
     #[arg(long, help = "Run as MCP server over stdio")]
     pub mcp: bool,
@@ -28,10 +31,14 @@ pub enum Command {
         output: PathBuf,
         #[arg(long, default_value = "0", help = "Rive file id written in header")]
         file_id: u64,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
     Validate {
         #[arg(help = "Path to .riv file to validate")]
         file: PathBuf,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
     Inspect {
         #[arg(help = "Path to .riv file to inspect")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,17 @@ fn main() {
     let cli = cli::Cli::parse();
 
     if cli.list_presets {
-        for preset in builder::artboard_presets() {
-            println!("{}: {}x{}", preset.name, preset.width, preset.height);
+        if cli.json {
+            let json = serde_json::to_string_pretty(&builder::artboard_presets())
+                .unwrap_or_else(|e| {
+                    eprintln!("JSON serialization failed: {}", e);
+                    std::process::exit(1);
+                });
+            println!("{}", json);
+        } else {
+            for preset in builder::artboard_presets() {
+                println!("{}: {}x{}", preset.name, preset.width, preset.height);
+            }
         }
         return;
     }
@@ -35,6 +44,7 @@ fn main() {
             input,
             output,
             file_id,
+            json,
         } => {
             let json_str = std::fs::read_to_string(&input).unwrap_or_else(|e| {
                 eprintln!("error reading {:?}: {}", input, e);
@@ -54,30 +64,50 @@ fn main() {
                 eprintln!("error writing {:?}: {}", output, e);
                 std::process::exit(1);
             });
-            eprintln!("wrote {} bytes to {:?}", bytes.len(), output);
+            if json {
+                let result = serde_json::json!({
+                    "bytes_written": bytes.len(),
+                    "output_path": output.display().to_string()
+                });
+                println!("{}", serde_json::to_string_pretty(&result).unwrap());
+            } else {
+                eprintln!("wrote {} bytes to {:?}", bytes.len(), output);
+            }
         }
-        cli::Command::Validate { file } => {
+        cli::Command::Validate { file, json } => {
             let bytes = std::fs::read(&file).unwrap_or_else(|e| {
                 eprintln!("error reading {:?}: {}", file, e);
                 std::process::exit(1);
             });
             match validator::validate_riv(&bytes) {
                 Ok(report) => {
-                    println!(
-                        "RIVE v{}.{} file_id={}",
-                        report.header.major_version,
-                        report.header.minor_version,
-                        report.header.file_id
-                    );
-                    println!("{} objects", report.object_count);
-                    if report.valid {
-                        println!("valid");
-                    } else {
-                        for err in &report.errors {
-                            eprintln!("error: {}", err);
+                    if json {
+                        let json_str =
+                            serde_json::to_string_pretty(&report).unwrap_or_else(|e| {
+                                eprintln!("JSON serialization failed: {}", e);
+                                std::process::exit(1);
+                            });
+                        println!("{}", json_str);
+                        if !report.valid {
+                            std::process::exit(1);
                         }
-                        eprintln!("invalid ({} errors)", report.errors.len());
-                        std::process::exit(1);
+                    } else {
+                        println!(
+                            "RIVE v{}.{} file_id={}",
+                            report.header.major_version,
+                            report.header.minor_version,
+                            report.header.file_id
+                        );
+                        println!("{} objects", report.object_count);
+                        if report.valid {
+                            println!("valid");
+                        } else {
+                            for err in &report.errors {
+                                eprintln!("error: {}", err);
+                            }
+                            eprintln!("invalid ({} errors)", report.errors.len());
+                            std::process::exit(1);
+                        }
                     }
                 }
                 Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,10 +65,12 @@ fn main() {
                 std::process::exit(1);
             });
             if json {
-                let result = serde_json::json!({
-                    "bytes_written": bytes.len(),
-                    "output_path": output.display().to_string()
-                });
+                #[derive(serde::Serialize)]
+                struct GenerateOutput { bytes_written: usize, output_path: String }
+                let result = GenerateOutput {
+                    bytes_written: bytes.len(),
+                    output_path: output.display().to_string(),
+                };
                 println!("{}", serde_json::to_string_pretty(&result).unwrap());
             } else {
                 eprintln!("wrote {} bytes to {:?}", bytes.len(), output);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ fn main() {
 
     if cli.list_presets {
         if cli.json {
-            let json = serde_json::to_string_pretty(&builder::artboard_presets())
-                .unwrap_or_else(|e| {
+            let json =
+                serde_json::to_string_pretty(&builder::artboard_presets()).unwrap_or_else(|e| {
                     eprintln!("JSON serialization failed: {}", e);
                     std::process::exit(1);
                 });
@@ -66,12 +66,19 @@ fn main() {
             });
             if json {
                 #[derive(serde::Serialize)]
-                struct GenerateOutput { bytes_written: usize, output_path: String }
+                struct GenerateOutput {
+                    bytes_written: usize,
+                    output_path: String,
+                }
                 let result = GenerateOutput {
                     bytes_written: bytes.len(),
                     output_path: output.display().to_string(),
                 };
-                println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                let json_str = serde_json::to_string_pretty(&result).unwrap_or_else(|e| {
+                    eprintln!("JSON serialization failed: {}", e);
+                    std::process::exit(1);
+                });
+                println!("{}", json_str);
             } else {
                 eprintln!("wrote {} bytes to {:?}", bytes.len(), output);
             }
@@ -84,11 +91,10 @@ fn main() {
             match validator::validate_riv(&bytes) {
                 Ok(report) => {
                     if json {
-                        let json_str =
-                            serde_json::to_string_pretty(&report).unwrap_or_else(|e| {
-                                eprintln!("JSON serialization failed: {}", e);
-                                std::process::exit(1);
-                            });
+                        let json_str = serde_json::to_string_pretty(&report).unwrap_or_else(|e| {
+                            eprintln!("JSON serialization failed: {}", e);
+                            std::process::exit(1);
+                        });
                         println!("{}", json_str);
                         if !report.valid {
                             std::process::exit(1);

--- a/src/validator/parser.rs
+++ b/src/validator/parser.rs
@@ -2,9 +2,7 @@ use std::collections::HashMap;
 
 use serde::Serialize;
 
-use crate::objects::core::{
-    BackingType, is_bool_property, property_backing_type,
-};
+use crate::objects::core::{BackingType, is_bool_property, property_backing_type};
 use crate::objects::generated_registry;
 
 use super::binary_reader::BinaryReader;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3371,3 +3371,81 @@ fn test_generate_validate_inspect_text_modifiers() {
     assert_eq!(uint_property(variation, "axisTag"), 2003265652);
     assert_eq!(float_property(variation, "axisValue"), 700.0);
 }
+
+#[test]
+fn test_validate_json_output() {
+    let (output, _guard) = generate_and_validate_output("minimal", "validate_json");
+    let result = cargo_run(&["validate", "--json", output.to_str().unwrap()]);
+    assert!(
+        result.status.success(),
+        "validate --json failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&result.stdout).expect("validate --json should output valid JSON");
+    assert!(json["valid"].as_bool().unwrap(), "report should be valid");
+    assert!(
+        json["object_count"].as_u64().unwrap() > 0,
+        "should have objects"
+    );
+    assert!(
+        json["header"]["major_version"].as_u64().is_some(),
+        "should have header version"
+    );
+}
+
+#[test]
+fn test_generate_json_output() {
+    let input = fixture_path("minimal.json");
+    let output = temp_output("generate_json");
+    cleanup(&output);
+    let _guard = CleanupOnDrop(output.clone());
+    let result = cargo_run(&[
+        "generate",
+        input.to_str().unwrap(),
+        "-o",
+        output.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(
+        result.status.success(),
+        "generate --json failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&result.stdout).expect("generate --json should output valid JSON");
+    assert!(
+        json["bytes_written"].as_u64().unwrap() > 0,
+        "should have bytes_written"
+    );
+    assert!(
+        json["output_path"].as_str().is_some(),
+        "should have output_path"
+    );
+}
+
+#[test]
+fn test_list_presets_json() {
+    let result = cargo_run(&["--list-presets", "--json"]);
+    assert!(
+        result.status.success(),
+        "--list-presets --json failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&result.stdout)
+        .expect("--list-presets --json should output valid JSON");
+    let presets = json.as_array().expect("should be an array");
+    assert!(!presets.is_empty(), "should have presets");
+    assert!(
+        presets[0]["name"].as_str().is_some(),
+        "preset should have name"
+    );
+    assert!(
+        presets[0]["width"].as_f64().is_some(),
+        "preset should have width"
+    );
+    assert!(
+        presets[0]["height"].as_f64().is_some(),
+        "preset should have height"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `--json` flag to `generate`, `validate`, and top-level `--list-presets` commands for structured JSON output, enabling scripting and CI/CD automation.
- Derives `Serialize` on `ArtboardPreset` so `--list-presets --json` serializes the preset array directly.
- Includes 3 new e2e tests covering all JSON output modes.

Partial fix for #97.

## Changes
| File | What |
|------|------|
| `src/builder/scene.rs` | Add `Serialize` derive + `use serde::Serialize` for `ArtboardPreset` |
| `src/cli/mod.rs` | Add `--json` bool flag to `Cli`, `Generate`, and `Validate` |
| `src/main.rs` | Handle JSON output in `list_presets`, `Generate`, and `Validate` match arms |
| `tests/e2e.rs` | Add `test_validate_json_output`, `test_generate_json_output`, `test_list_presets_json` |

## Test plan
- [x] `cargo test` — all 506 tests pass (391 unit + 115 e2e including 3 new)
- [x] `cargo build --features mcp` — compiles cleanly
- [x] Manual verification of all three JSON output modes:
  - `cargo run -- generate tests/fixtures/minimal.json -o /tmp/test.riv --json`
  - `cargo run -- validate /tmp/test.riv --json`
  - `cargo run -- --list-presets --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global --json flag for structured machine-readable output.
  * JSON output for list-presets, generate, and validate flows; generate reports bytes_written and output_path; validate emits a JSON validation report.
  * Preset objects now support serialization for JSON tooling.

* **Tests**
  * New end-to-end tests validating JSON output for list-presets, generate, and validate.

* **Style/Refactor**
  * Formatting and minor code reflows with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->