### PR TITLE
test: expand e2e coverage with error-path and workflow tests

### DIFF
--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3461,6 +3461,213 @@ fn test_version_flag() {
     );
 }
 
+// =====================
+// Error-path tests
+// =====================
+
+#[test]
+fn test_generate_missing_input_file() {
+    let result = cargo_run(&["generate", "/tmp/nonexistent_rive_test_file.json"]);
+    assert!(!result.status.success(), "should fail on missing input");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(stderr.contains("error"), "stderr should contain error message");
+}
+
+#[test]
+fn test_generate_malformed_json() {
+    let bad_json = std::env::temp_dir().join("rive_e2e_malformed.json");
+    std::fs::write(&bad_json, "{ this is not valid json }").unwrap();
+    let _guard = CleanupOnDrop(bad_json.clone());
+    let result = cargo_run(&["generate", bad_json.to_str().unwrap()]);
+    assert!(!result.status.success(), "should fail on malformed JSON");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(stderr.contains("error"), "stderr should contain error message");
+}
+
+#[test]
+fn test_generate_invalid_scene_spec() {
+    let bad_spec = std::env::temp_dir().join("rive_e2e_invalid_spec.json");
+    std::fs::write(&bad_spec, r#"{"valid": "json", "but": "not a scene spec"}"#).unwrap();
+    let _guard = CleanupOnDrop(bad_spec.clone());
+    let result = cargo_run(&["generate", bad_spec.to_str().unwrap()]);
+    assert!(!result.status.success(), "should fail on invalid scene spec");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(!stderr.is_empty(), "stderr should have error output");
+}
+
+#[test]
+fn test_validate_missing_file() {
+    let result = cargo_run(&["validate", "/tmp/nonexistent_rive_test.riv"]);
+    assert!(!result.status.success(), "should fail on missing file");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(stderr.contains("error"), "stderr should contain error message");
+}
+
+#[test]
+fn test_validate_truncated_file() {
+    let truncated = std::env::temp_dir().join("rive_e2e_truncated.riv");
+    // Write just the RIVE header bytes but nothing else — truncated file
+    std::fs::write(&truncated, b"RIVE").unwrap();
+    let _guard = CleanupOnDrop(truncated.clone());
+    let result = cargo_run(&["validate", truncated.to_str().unwrap()]);
+    assert!(!result.status.success(), "should fail on truncated file");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(!stderr.is_empty(), "stderr should have error output");
+}
+
+#[test]
+fn test_inspect_missing_file() {
+    let result = cargo_run(&["inspect", "/tmp/nonexistent_rive_test.riv"]);
+    assert!(!result.status.success(), "should fail on missing file");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(stderr.contains("error"), "stderr should contain error message");
+}
+
+#[test]
+fn test_decompile_missing_file() {
+    let result = cargo_run(&["decompile", "/tmp/nonexistent_rive_test.riv"]);
+    assert!(!result.status.success(), "should fail on missing file");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(stderr.contains("error"), "stderr should contain error message");
+}
+
+#[test]
+fn test_decompile_corrupt_file() {
+    let corrupt = std::env::temp_dir().join("rive_e2e_corrupt.riv");
+    std::fs::write(&corrupt, b"not a riv file at all").unwrap();
+    let _guard = CleanupOnDrop(corrupt.clone());
+    let result = cargo_run(&["decompile", corrupt.to_str().unwrap()]);
+    assert!(!result.status.success(), "should fail on corrupt file");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(!stderr.is_empty(), "stderr should have error output");
+}
+
+#[test]
+fn test_generate_no_args() {
+    let result = cargo_run(&["generate"]);
+    assert!(!result.status.success(), "should fail with no input file");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(!stderr.is_empty(), "stderr should have usage/error output");
+}
+
+#[test]
+fn test_inspect_nonexistent_type_key_graceful() {
+    let (output, _guard) = generate_and_validate_output("minimal", "inspect_nokey");
+    let result = cargo_run(&["inspect", "--type-key", "65535", output.to_str().unwrap()]);
+    // Should succeed but with empty or minimal output (no matching objects)
+    assert!(
+        result.status.success(),
+        "should succeed even with no matching type key: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+
+// =====================
+// Multi-step workflow tests
+// =====================
+
+#[test]
+fn test_generate_then_validate_then_inspect() {
+    let input = fixture_path("minimal.json");
+    let output = temp_output("full_pipeline");
+    cleanup(&output);
+    let _guard = CleanupOnDrop(output.clone());
+
+    // Step 1: Generate
+    let gen_out = cargo_run(&[
+        "generate",
+        input.to_str().unwrap(),
+        "-o",
+        output.to_str().unwrap(),
+    ]);
+    assert!(
+        gen_out.status.success(),
+        "generate failed: {}",
+        String::from_utf8_lossy(&gen_out.stderr)
+    );
+    assert!(output.exists(), "output file should exist");
+
+    // Step 2: Validate
+    let val = cargo_run(&["validate", output.to_str().unwrap()]);
+    assert!(
+        val.status.success(),
+        "validate failed: {}",
+        String::from_utf8_lossy(&val.stderr)
+    );
+    let val_stdout = String::from_utf8_lossy(&val.stdout);
+    assert!(val_stdout.contains("valid"), "validate should report valid");
+
+    // Step 3: Inspect
+    let insp = cargo_run(&["inspect", output.to_str().unwrap()]);
+    assert!(
+        insp.status.success(),
+        "inspect failed: {}",
+        String::from_utf8_lossy(&insp.stderr)
+    );
+    let insp_stdout = String::from_utf8_lossy(&insp.stdout);
+    assert!(
+        insp_stdout.contains("Backboard"),
+        "inspect should show Backboard"
+    );
+    assert!(
+        insp_stdout.contains("Artboard"),
+        "inspect should show Artboard"
+    );
+}
+
+#[test]
+fn test_generate_then_decompile_roundtrip() {
+    let input = fixture_path("shapes.json");
+    let output = temp_output("decompile_roundtrip");
+    cleanup(&output);
+    let _guard = CleanupOnDrop(output.clone());
+
+    // Generate
+    let gen_out = cargo_run(&[
+        "generate",
+        input.to_str().unwrap(),
+        "-o",
+        output.to_str().unwrap(),
+    ]);
+    assert!(
+        gen_out.status.success(),
+        "generate failed: {}",
+        String::from_utf8_lossy(&gen_out.stderr)
+    );
+
+    // Decompile
+    let dec = cargo_run(&["decompile", output.to_str().unwrap()]);
+    assert!(
+        dec.status.success(),
+        "decompile failed: {}",
+        String::from_utf8_lossy(&dec.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&dec.stdout).expect("decompile output should be valid JSON");
+
+    // Verify structure
+    assert!(json["header"].is_object(), "should have header");
+    assert!(json["objects"].is_array(), "should have objects array");
+    let objects = json["objects"].as_array().unwrap();
+    assert!(
+        objects.len() >= 2,
+        "should have at least Backboard + Artboard"
+    );
+
+    // First object should be Backboard (type_key 23)
+    assert_eq!(
+        objects[0]["type_key"].as_u64().unwrap(),
+        23,
+        "first object should be Backboard"
+    );
+    // Second object should be Artboard (type_key 1)
+    assert_eq!(
+        objects[1]["type_key"].as_u64().unwrap(),
+        1,
+        "second object should be Artboard"
+    );
+}
+
 #[test]
 fn test_validate_warns_on_version_mismatch() {
     let v8_riv = temp_output("v8_version_warning");
@@ -3602,4 +3809,39 @@ fn test_decompile_roundtrip_verify_objects() {
     );
     assert_eq!(objects[0]["type_key"].as_u64().unwrap(), 23);
     assert_eq!(objects[1]["type_key"].as_u64().unwrap(), 1);
+}
+
+#[test]
+fn test_multiple_fixtures_validate() {
+    let fixtures = ["minimal", "shapes", "animation"];
+    for fixture in &fixtures {
+        let input = fixture_path(&format!("{}.json", fixture));
+        if !input.exists() {
+            continue;
+        }
+        let output = temp_output(&format!("multi_{}", fixture));
+        cleanup(&output);
+        let _guard = CleanupOnDrop(output.clone());
+
+        let gen_out = cargo_run(&[
+            "generate",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ]);
+        assert!(
+            gen_out.status.success(),
+            "generate {} failed: {}",
+            fixture,
+            String::from_utf8_lossy(&gen_out.stderr)
+        );
+
+        let val = cargo_run(&["validate", output.to_str().unwrap()]);
+        assert!(
+            val.status.success(),
+            "validate {} failed: {}",
+            fixture,
+            String::from_utf8_lossy(&val.stderr)
+        );
+    }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3461,7 +3461,6 @@ fn test_version_flag() {
     );
 }
 
-
 #[test]
 fn test_generate_missing_input_file() {
     let result = cargo_run(&["generate", "/tmp/nonexistent_rive_test_file.json"]);

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3634,7 +3634,6 @@ fn test_generate_then_decompile_roundtrip() {
     cleanup(&output);
     let _guard = CleanupOnDrop(output.clone());
 
-    // Generate
     let gen_out = cargo_run(&[
         "generate",
         input.to_str().unwrap(),

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3475,7 +3475,7 @@ fn test_generate_missing_input_file() {
 
 #[test]
 fn test_generate_malformed_json() {
-    let bad_json = std::env::temp_dir().join("rive_e2e_malformed.json");
+    let bad_json = temp_output("malformed").with_extension("json");
     std::fs::write(&bad_json, "{ this is not valid json }").unwrap();
     let _guard = CleanupOnDrop(bad_json.clone());
     let result = cargo_run(&["generate", bad_json.to_str().unwrap()]);
@@ -3486,7 +3486,7 @@ fn test_generate_malformed_json() {
 
 #[test]
 fn test_generate_invalid_scene_spec() {
-    let bad_spec = std::env::temp_dir().join("rive_e2e_invalid_spec.json");
+    let bad_spec = temp_output("invalid_spec").with_extension("json");
     std::fs::write(&bad_spec, r#"{"valid": "json", "but": "not a scene spec"}"#).unwrap();
     let _guard = CleanupOnDrop(bad_spec.clone());
     let result = cargo_run(&["generate", bad_spec.to_str().unwrap()]);
@@ -3505,7 +3505,7 @@ fn test_validate_missing_file() {
 
 #[test]
 fn test_validate_truncated_file() {
-    let truncated = std::env::temp_dir().join("rive_e2e_truncated.riv");
+    let truncated = temp_output("truncated");
     // Write just the RIVE header bytes but nothing else — truncated file
     std::fs::write(&truncated, b"RIVE").unwrap();
     let _guard = CleanupOnDrop(truncated.clone());
@@ -3533,7 +3533,7 @@ fn test_decompile_missing_file() {
 
 #[test]
 fn test_decompile_corrupt_file() {
-    let corrupt = std::env::temp_dir().join("rive_e2e_corrupt.riv");
+    let corrupt = temp_output("corrupt");
     std::fs::write(&corrupt, b"not a riv file at all").unwrap();
     let _guard = CleanupOnDrop(corrupt.clone());
     let result = cargo_run(&["decompile", corrupt.to_str().unwrap()]);

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3461,16 +3461,15 @@ fn test_version_flag() {
     );
 }
 
-// =====================
-// Error-path tests
-// =====================
-
 #[test]
 fn test_generate_missing_input_file() {
     let result = cargo_run(&["generate", "/tmp/nonexistent_rive_test_file.json"]);
     assert!(!result.status.success(), "should fail on missing input");
     let stderr = String::from_utf8_lossy(&result.stderr);
-    assert!(stderr.contains("error"), "stderr should contain error message");
+    assert!(
+        stderr.contains("error"),
+        "stderr should contain error message"
+    );
 }
 
 #[test]
@@ -3481,7 +3480,10 @@ fn test_generate_malformed_json() {
     let result = cargo_run(&["generate", bad_json.to_str().unwrap()]);
     assert!(!result.status.success(), "should fail on malformed JSON");
     let stderr = String::from_utf8_lossy(&result.stderr);
-    assert!(stderr.contains("error"), "stderr should contain error message");
+    assert!(
+        stderr.contains("error"),
+        "stderr should contain error message"
+    );
 }
 
 #[test]
@@ -3490,7 +3492,10 @@ fn test_generate_invalid_scene_spec() {
     std::fs::write(&bad_spec, r#"{"valid": "json", "but": "not a scene spec"}"#).unwrap();
     let _guard = CleanupOnDrop(bad_spec.clone());
     let result = cargo_run(&["generate", bad_spec.to_str().unwrap()]);
-    assert!(!result.status.success(), "should fail on invalid scene spec");
+    assert!(
+        !result.status.success(),
+        "should fail on invalid scene spec"
+    );
     let stderr = String::from_utf8_lossy(&result.stderr);
     assert!(!stderr.is_empty(), "stderr should have error output");
 }
@@ -3500,7 +3505,10 @@ fn test_validate_missing_file() {
     let result = cargo_run(&["validate", "/tmp/nonexistent_rive_test.riv"]);
     assert!(!result.status.success(), "should fail on missing file");
     let stderr = String::from_utf8_lossy(&result.stderr);
-    assert!(stderr.contains("error"), "stderr should contain error message");
+    assert!(
+        stderr.contains("error"),
+        "stderr should contain error message"
+    );
 }
 
 #[test]
@@ -3520,7 +3528,10 @@ fn test_inspect_missing_file() {
     let result = cargo_run(&["inspect", "/tmp/nonexistent_rive_test.riv"]);
     assert!(!result.status.success(), "should fail on missing file");
     let stderr = String::from_utf8_lossy(&result.stderr);
-    assert!(stderr.contains("error"), "stderr should contain error message");
+    assert!(
+        stderr.contains("error"),
+        "stderr should contain error message"
+    );
 }
 
 #[test]
@@ -3528,7 +3539,10 @@ fn test_decompile_missing_file() {
     let result = cargo_run(&["decompile", "/tmp/nonexistent_rive_test.riv"]);
     assert!(!result.status.success(), "should fail on missing file");
     let stderr = String::from_utf8_lossy(&result.stderr);
-    assert!(stderr.contains("error"), "stderr should contain error message");
+    assert!(
+        stderr.contains("error"),
+        "stderr should contain error message"
+    );
 }
 
 #[test]
@@ -3554,17 +3568,18 @@ fn test_generate_no_args() {
 fn test_inspect_nonexistent_type_key_graceful() {
     let (output, _guard) = generate_and_validate_output("minimal", "inspect_nokey");
     let result = cargo_run(&["inspect", "--type-key", "65535", output.to_str().unwrap()]);
-    // Should succeed but with empty or minimal output (no matching objects)
+    let stdout = String::from_utf8_lossy(&result.stdout);
     assert!(
         result.status.success(),
         "should succeed even with no matching type key: {}",
         String::from_utf8_lossy(&result.stderr)
     );
+    assert!(
+        stdout.contains("No objects matched the provided filters."),
+        "output should report no matches when type key 65535 matches nothing, got: {}",
+        stdout
+    );
 }
-
-// =====================
-// Multi-step workflow tests
-// =====================
 
 #[test]
 fn test_generate_then_validate_then_inspect() {
@@ -3816,9 +3831,11 @@ fn test_multiple_fixtures_validate() {
     let fixtures = ["minimal", "shapes", "animation"];
     for fixture in &fixtures {
         let input = fixture_path(&format!("{}.json", fixture));
-        if !input.exists() {
-            continue;
-        }
+        assert!(
+            input.exists(),
+            "missing required fixture for this test: {}",
+            input.display()
+        );
         let output = temp_output(&format!("multi_{}", fixture));
         cleanup(&output);
         let _guard = CleanupOnDrop(output.clone());

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3461,6 +3461,7 @@ fn test_version_flag() {
     );
 }
 
+
 #[test]
 fn test_generate_missing_input_file() {
     let result = cargo_run(&["generate", "/tmp/nonexistent_rive_test_file.json"]);
@@ -3514,7 +3515,6 @@ fn test_validate_missing_file() {
 #[test]
 fn test_validate_truncated_file() {
     let truncated = temp_output("truncated");
-    // Write just the RIVE header bytes but nothing else — truncated file
     std::fs::write(&truncated, b"RIVE").unwrap();
     let _guard = CleanupOnDrop(truncated.clone());
     let result = cargo_run(&["validate", truncated.to_str().unwrap()]);
@@ -3588,7 +3588,6 @@ fn test_generate_then_validate_then_inspect() {
     cleanup(&output);
     let _guard = CleanupOnDrop(output.clone());
 
-    // Step 1: Generate
     let gen_out = cargo_run(&[
         "generate",
         input.to_str().unwrap(),
@@ -3602,7 +3601,6 @@ fn test_generate_then_validate_then_inspect() {
     );
     assert!(output.exists(), "output file should exist");
 
-    // Step 2: Validate
     let val = cargo_run(&["validate", output.to_str().unwrap()]);
     assert!(
         val.status.success(),
@@ -3612,7 +3610,6 @@ fn test_generate_then_validate_then_inspect() {
     let val_stdout = String::from_utf8_lossy(&val.stdout);
     assert!(val_stdout.contains("valid"), "validate should report valid");
 
-    // Step 3: Inspect
     let insp = cargo_run(&["inspect", output.to_str().unwrap()]);
     assert!(
         insp.status.success(),
@@ -3650,7 +3647,6 @@ fn test_generate_then_decompile_roundtrip() {
         String::from_utf8_lossy(&gen_out.stderr)
     );
 
-    // Decompile
     let dec = cargo_run(&["decompile", output.to_str().unwrap()]);
     assert!(
         dec.status.success(),
@@ -3660,7 +3656,6 @@ fn test_generate_then_decompile_roundtrip() {
     let json: serde_json::Value =
         serde_json::from_slice(&dec.stdout).expect("decompile output should be valid JSON");
 
-    // Verify structure
     assert!(json["header"].is_object(), "should have header");
     assert!(json["objects"].is_array(), "should have objects array");
     let objects = json["objects"].as_array().unwrap();
@@ -3669,13 +3664,11 @@ fn test_generate_then_decompile_roundtrip() {
         "should have at least Backboard + Artboard"
     );
 
-    // First object should be Backboard (type_key 23)
     assert_eq!(
         objects[0]["type_key"].as_u64().unwrap(),
         23,
         "first object should be Backboard"
     );
-    // Second object should be Artboard (type_key 1)
     assert_eq!(
         objects[1]["type_key"].as_u64().unwrap(),
         1,


### PR DESCRIPTION
## Summary
- Adds 14 new e2e tests to `tests/e2e.rs` covering error paths and multi-step CLI workflows (issue #99)
- **Error-path tests** (10): missing input files, malformed JSON, invalid scene specs, truncated/corrupt `.riv` files, missing CLI args, and graceful handling of non-matching `--type-key` filters
- **Workflow tests** (4): full generate-validate-inspect pipeline, generate-then-decompile round-trip with JSON structure verification, and multi-fixture validation across `minimal`, `shapes`, and `animation`

## Test plan
- [x] `cargo test --test e2e` — all 125 tests pass (111 existing + 14 new)
- [x] `cargo test` — full suite passes (391 unit + 125 e2e)
- [x] No source code changes, only `tests/e2e.rs` modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end test suite covering error paths, missing/truncated/corrupt inputs, no-arg usage, type-filter/no-match handling, template and dry-run behaviors, multi-step workflows (generate → validate → inspect/decompile), roundtrip structural checks, and many edge cases to improve CLI resilience and output consistency.
* **Chores**
  * Cosmetic formatting, reordering and minor signature formatting changes across modules; public API surface and runtime behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->