### PR TITLE
feat: validator version warnings and parent-ID validation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,9 @@ fn main() {
                             std::process::exit(1);
                         }
                     }
+                    for warning in &report.warnings {
+                        eprintln!("warning: {}", warning);
+                    }
                 }
                 Err(e) => {
                     eprintln!("invalid: {}", e);

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -208,7 +208,6 @@ mod tests {
     fn test_validate_riv_parent_id_out_of_range() {
         use crate::objects::core::{Property, PropertyValue, RiveObject};
 
-        // Create an object with an out-of-range parentId
         struct BadParent;
         impl RiveObject for BadParent {
             fn type_key(&self) -> u16 {

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -19,6 +19,8 @@ pub struct ValidationReport {
     pub object_count: usize,
     pub type_counts: HashMap<u16, usize>,
     pub errors: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
     pub valid: bool,
 }
 
@@ -28,6 +30,15 @@ pub fn validate_riv(data: &[u8]) -> Result<ValidationReport, String> {
     let mut type_counts: HashMap<u16, usize> = HashMap::new();
     for obj in &parsed.objects {
         *type_counts.entry(obj.type_key).or_insert(0) += 1;
+    }
+
+    let mut warnings: Vec<String> = Vec::new();
+
+    if parsed.header.major_version != 7 {
+        warnings.push(format!(
+            "unexpected major version {} (expected 7)",
+            parsed.header.major_version
+        ));
     }
 
     let mut errors: Vec<String> = Vec::new();
@@ -78,6 +89,22 @@ pub fn validate_riv(data: &[u8]) -> Result<ValidationReport, String> {
         }
     }
 
+    // Parent-ID range check
+    for (idx, obj) in parsed.objects.iter().enumerate() {
+        for prop in &obj.properties {
+            if prop.key == property_keys::COMPONENT_PARENT_ID {
+                if let PropertyValueRead::UInt(parent_idx) = &prop.value {
+                    if *parent_idx as usize >= parsed.objects.len() {
+                        errors.push(format!(
+                            "object {} has parentId {} which exceeds object count {}",
+                            idx, parent_idx, parsed.objects.len()
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
     let valid = errors.is_empty();
 
     Ok(ValidationReport {
@@ -85,6 +112,7 @@ pub fn validate_riv(data: &[u8]) -> Result<ValidationReport, String> {
         object_count: parsed.objects.len(),
         type_counts,
         errors,
+        warnings,
         valid,
     })
 }
@@ -140,5 +168,92 @@ mod tests {
         let report = validate_riv(&data).unwrap();
 
         assert!(report.valid, "unexpected errors: {:?}", report.errors);
+    }
+
+    #[test]
+    fn test_validate_riv_version_warning() {
+        // Manually construct a .riv with major version 8
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"RIVE"); // fingerprint
+        bytes.push(8); // major version = 8 (LEB128)
+        bytes.push(0); // minor version = 0
+        bytes.push(0); // file_id = 0
+        bytes.push(0); // empty ToC (0-terminator)
+        // Backboard object: type key 23
+        bytes.push(23); // type_key
+        bytes.push(0); // no properties (terminator)
+        // Artboard object: type key 1
+        bytes.push(1); // type_key
+        bytes.push(0); // no properties (terminator)
+
+        let report = validate_riv(&bytes).unwrap();
+        assert!(
+            report.warnings.iter().any(|w| w.contains("major version")),
+            "should warn about non-7 major version, got warnings: {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn test_validate_riv_no_version_warning_for_v7() {
+        let backboard = Backboard;
+        let artboard = Artboard::new("Test".to_string(), 500.0, 500.0);
+        let data = encode_riv(&[&backboard, &artboard], 0);
+        let report = validate_riv(&data).unwrap();
+        assert!(
+            report.warnings.is_empty(),
+            "should have no warnings for v7, got: {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn test_validate_riv_parent_id_out_of_range() {
+        use crate::objects::core::{Property, PropertyValue, RiveObject};
+
+        // Create an object with an out-of-range parentId
+        struct BadParent;
+        impl RiveObject for BadParent {
+            fn type_key(&self) -> u16 {
+                3
+            } // Node type
+            fn properties(&self) -> Vec<Property> {
+                vec![Property {
+                    key: 5, // parentId
+                    value: PropertyValue::UInt(999), // out of range
+                }]
+            }
+        }
+
+        let backboard = Backboard;
+        let artboard = Artboard::new("Test".to_string(), 500.0, 500.0);
+        let bad = BadParent;
+        let data = encode_riv(&[&backboard, &artboard, &bad], 0);
+        let report = validate_riv(&data).unwrap();
+        assert!(
+            !report.valid,
+            "should be invalid due to out-of-range parentId"
+        );
+        assert!(
+            report.errors.iter().any(|e| e.contains("parentId")),
+            "should have parentId error, got: {:?}",
+            report.errors
+        );
+    }
+
+    #[test]
+    fn test_validate_riv_valid_parent_id() {
+        let backboard = Backboard;
+        let artboard = Artboard::new("Test".to_string(), 500.0, 500.0);
+        // Shape with parentId=0 (Backboard) is technically valid index-wise
+        use crate::objects::shapes::Shape;
+        let shape = Shape::new("TestShape".to_string(), 0);
+        let data = encode_riv(&[&backboard, &artboard, &shape], 0);
+        let report = validate_riv(&data).unwrap();
+        assert!(
+            !report.errors.iter().any(|e| e.contains("parentId")),
+            "should not have parentId errors for valid references, got: {:?}",
+            report.errors
+        );
     }
 }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -87,16 +87,19 @@ pub fn validate_riv(data: &[u8]) -> Result<ValidationReport, String> {
             }
         }
 
-        // Parent-ID range check
         for prop in &obj.properties {
-            if prop.key == property_keys::COMPONENT_PARENT_ID {
-                if let PropertyValueRead::UInt(parent_idx) = &prop.value {
-                    if *parent_idx as usize >= parsed.objects.len() {
-                        errors.push(format!(
-                            "object {} has parentId {} which exceeds object count {}",
-                            idx, parent_idx, parsed.objects.len()
-                        ));
-                    }
+            if prop.key == property_keys::COMPONENT_PARENT_ID
+                && let PropertyValueRead::UInt(parent_idx) = &prop.value
+            {
+                let out_of_range =
+                    usize::try_from(*parent_idx).map_or(true, |p| p >= parsed.objects.len());
+                if out_of_range {
+                    errors.push(format!(
+                        "object {} has parentId {} which exceeds object count {}",
+                        idx,
+                        parent_idx,
+                        parsed.objects.len()
+                    ));
                 }
             }
         }
@@ -169,19 +172,16 @@ mod tests {
 
     #[test]
     fn test_validate_riv_version_warning() {
-        // Manually construct a .riv with major version 8
         let mut bytes = Vec::new();
-        bytes.extend_from_slice(b"RIVE"); // fingerprint
-        bytes.push(8); // major version = 8 (LEB128)
-        bytes.push(0); // minor version = 0
-        bytes.push(0); // file_id = 0
-        bytes.push(0); // empty ToC (0-terminator)
-        // Backboard object: type key 23
-        bytes.push(23); // type_key
-        bytes.push(0); // no properties (terminator)
-        // Artboard object: type key 1
-        bytes.push(1); // type_key
-        bytes.push(0); // no properties (terminator)
+        bytes.extend_from_slice(b"RIVE");
+        bytes.push(8);
+        bytes.push(0);
+        bytes.push(0);
+        bytes.push(0);
+        bytes.push(23);
+        bytes.push(0);
+        bytes.push(1);
+        bytes.push(0);
 
         let report = validate_riv(&bytes).unwrap();
         assert!(
@@ -213,11 +213,11 @@ mod tests {
         impl RiveObject for BadParent {
             fn type_key(&self) -> u16 {
                 3
-            } // Node type
+            }
             fn properties(&self) -> Vec<Property> {
                 vec![Property {
-                    key: 5, // parentId
-                    value: PropertyValue::UInt(999), // out of range
+                    key: 5,
+                    value: PropertyValue::UInt(999),
                 }]
             }
         }
@@ -242,7 +242,6 @@ mod tests {
     fn test_validate_riv_valid_parent_id() {
         let backboard = Backboard;
         let artboard = Artboard::new("Test".to_string(), 500.0, 500.0);
-        // Shape with parentId=0 (Backboard) is technically valid index-wise
         use crate::objects::shapes::Shape;
         let shape = Shape::new("TestShape".to_string(), 0);
         let data = encode_riv(&[&backboard, &artboard, &shape], 0);

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -62,7 +62,6 @@ pub fn validate_riv(data: &[u8]) -> Result<ValidationReport, String> {
     for (idx, obj) in parsed.objects.iter().enumerate() {
         if obj.type_key == type_keys::IMAGE_ASSET {
             image_assets_seen += 1;
-            continue;
         }
         if obj.type_key == type_keys::IMAGE {
             let asset_id = obj
@@ -87,10 +86,8 @@ pub fn validate_riv(data: &[u8]) -> Result<ValidationReport, String> {
                 )),
             }
         }
-    }
 
-    // Parent-ID range check
-    for (idx, obj) in parsed.objects.iter().enumerate() {
+        // Parent-ID range check
         for prop in &obj.properties {
             if prop.key == property_keys::COMPONENT_PARENT_ID {
                 if let PropertyValueRead::UInt(parent_idx) = &prop.value {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3482,8 +3482,8 @@ fn test_validate_warns_on_version_mismatch() {
     assert!(result.status.success(), "validate should succeed for v8");
     let stderr = String::from_utf8_lossy(&result.stderr);
     assert!(
-        stderr.contains("warning"),
-        "should output version warning: stderr={}",
+        stderr.contains("major version"),
+        "should output major version warning: stderr={}",
         stderr
     );
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3463,7 +3463,8 @@ fn test_version_flag() {
 
 #[test]
 fn test_validate_warns_on_version_mismatch() {
-    let v8_riv = std::env::temp_dir().join("rive_e2e_v8.riv");
+    let v8_riv = temp_output("v8_version_warning");
+    cleanup(&v8_riv);
     let mut bytes = Vec::new();
     bytes.extend_from_slice(b"RIVE");
     bytes.push(8);

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3462,6 +3462,32 @@ fn test_version_flag() {
 }
 
 #[test]
+fn test_validate_warns_on_version_mismatch() {
+    let v8_riv = std::env::temp_dir().join("rive_e2e_v8.riv");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"RIVE");
+    bytes.push(8);
+    bytes.push(0);
+    bytes.push(0);
+    bytes.push(0);
+    bytes.push(23);
+    bytes.push(0);
+    bytes.push(1);
+    bytes.push(0);
+    std::fs::write(&v8_riv, &bytes).unwrap();
+    let _guard = CleanupOnDrop(v8_riv.clone());
+
+    let result = cargo_run(&["validate", v8_riv.to_str().unwrap()]);
+    assert!(result.status.success(), "validate should succeed for v8");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("warning"),
+        "should output version warning: stderr={}",
+        stderr
+    );
+}
+
+#[test]
 fn test_help_output() {
     let output = cargo_run(&["--help"]);
     assert!(output.status.success(), "--help failed");
@@ -3555,4 +3581,24 @@ fn test_ai_generate_help() {
         stdout.contains("Examples:"),
         "ai generate help should include examples"
     );
+}
+
+#[test]
+fn test_decompile_roundtrip_verify_objects() {
+    let (output, _guard) = generate_and_validate_output("minimal", "decompile_rt");
+    let dec = cargo_run(&["decompile", output.to_str().unwrap()]);
+    assert!(
+        dec.status.success(),
+        "decompile failed: {}",
+        String::from_utf8_lossy(&dec.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&dec.stdout).expect("should be valid JSON");
+    let objects = json["objects"].as_array().expect("should have objects");
+    assert!(
+        objects.len() >= 2,
+        "should have at least 2 objects (Backboard + Artboard)"
+    );
+    assert_eq!(objects[0]["type_key"].as_u64().unwrap(), 23);
+    assert_eq!(objects[1]["type_key"].as_u64().unwrap(), 1);
 }


### PR DESCRIPTION
## Summary
- Add `warnings` field to `ValidationReport` with `#[serde(skip_serializing_if = "Vec::is_empty")]` so it only appears in JSON when non-empty
- Emit a warning when `.riv` major version is not 7 (the expected version)
- Add parent-ID range validation: flag objects whose `parentId` property references an index beyond the object count
- Display warnings on stderr in the `validate` CLI command (after valid/invalid output)
- Add 4 unit tests: version warning, no warning for v7, parent-ID out of range, valid parent-ID
- Add 2 e2e tests: version mismatch warning via CLI, decompile round-trip object verification

Closes #101

## Test plan
- [x] `cargo test` -- all 114 tests pass (including 6 new tests)
- [x] `cargo build --features mcp` -- compiles cleanly
- [x] `cargo test --test e2e test_validate_warns_on_version` -- e2e version warning test passes
- [ ] Verify warnings appear in `cargo run -- validate` output for a non-v7 .riv file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now reports version mismatch warnings when appropriate
  * Added validation check to ensure parent-ID references point to valid objects
  * Warning messages are now included in validation reports

* **Tests**
  * Added end-to-end tests for version validation and decompile functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->