### PR TITLE
feat: add --json flag to ai generate and ai lab commands

### DIFF
--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -9,4 +9,4 @@ pub use config::AiConfig;
 pub use error::AiError;
 pub use eval::run_eval_suite;
 pub use provider::create_provider;
-pub use repair::{RepairEngine, format_repair_summary, remediation_hints};
+pub use repair::{RepairAttempt, RepairEngine, format_repair_summary, remediation_hints};

--- a/src/ai/repair.rs
+++ b/src/ai/repair.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use serde_json::Value;
 
 use crate::ai::AiError;
@@ -8,7 +9,7 @@ use crate::validator::validate_riv;
 
 const DEFAULT_MAX_RETRIES: u8 = 3;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum ErrorCategory {
     Schema,
     Build,
@@ -27,14 +28,14 @@ impl std::fmt::Display for ErrorCategory {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct RepairDiagnostic {
     pub category: ErrorCategory,
     pub message: String,
     pub auto_fixable: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct RepairAttempt {
     pub attempt: u8,
     pub diagnostics: Vec<RepairDiagnostic>,
@@ -42,10 +43,12 @@ pub struct RepairAttempt {
     pub succeeded: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct RepairResult {
     #[allow(dead_code)] // read in tests and available for callers
+    #[serde(skip)]
     pub scene_json: Value,
+    #[serde(skip)]
     pub riv_bytes: Vec<u8>,
     pub attempts: Vec<RepairAttempt>,
     pub total_retries: u8,

--- a/src/ai/repair.rs
+++ b/src/ai/repair.rs
@@ -45,7 +45,7 @@ pub struct RepairAttempt {
 
 #[derive(Debug, Serialize)]
 pub struct RepairResult {
-    #[allow(dead_code)] // read in tests and available for callers
+    #[allow(dead_code)]
     #[serde(skip)]
     pub scene_json: Value,
     #[serde(skip)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -150,6 +150,8 @@ pub enum AiCommand {
             help = "Max auto-repair retries (0 = no repair)"
         )]
         max_retries: u8,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
     #[command(about = "Run evaluation suites for AI-generated animations")]
     Lab {
@@ -173,5 +175,7 @@ pub enum AiCommand {
         baseline: Option<PathBuf>,
         #[arg(long, help = "Write baseline JSON from this run")]
         write_baseline: Option<PathBuf>,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,12 +252,19 @@ fn main() {
                             std::process::exit(1);
                         });
                         if json {
-                            let json_result = serde_json::json!({
-                                "output_path": output.display().to_string(),
-                                "bytes_written": bytes.len(),
-                                "retries": total_retries,
-                                "attempts": attempts
-                            });
+                            #[derive(serde::Serialize)]
+                            struct AiGenerateOutput<'a> {
+                                output_path: String,
+                                bytes_written: usize,
+                                retries: u8,
+                                attempts: &'a [ai::RepairAttempt],
+                            }
+                            let json_result = AiGenerateOutput {
+                                output_path: output.display().to_string(),
+                                bytes_written: bytes.len(),
+                                retries: total_retries,
+                                attempts: &attempts,
+                            };
                             println!("{}", serde_json::to_string_pretty(&json_result).unwrap());
                         } else {
                             eprintln!("wrote {} bytes to {:?}", bytes.len(), output);

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,6 +206,7 @@ fn main() {
                 model,
                 provider: provider_name,
                 max_retries,
+                json,
             } => {
                 let config = ai::AiConfig::resolve(model, provider_name).unwrap_or_else(|e| {
                     eprintln!("AI config error: {}", e);
@@ -237,17 +238,30 @@ fn main() {
                 let engine = ai::RepairEngine::new(max_retries);
                 match engine.repair(scene_json, file_id) {
                     Ok(result) => {
-                        if result.total_retries > 0 {
-                            eprintln!("repair succeeded after {} retry(ies)", result.total_retries);
-                            let summary = ai::format_repair_summary(&result.attempts);
+                        let bytes = result.riv_bytes;
+                        let attempts = result.attempts;
+                        let total_retries = result.total_retries;
+
+                        if total_retries > 0 && !json {
+                            eprintln!("repair succeeded after {} retry(ies)", total_retries);
+                            let summary = ai::format_repair_summary(&attempts);
                             eprint!("{}", summary);
                         }
-                        let bytes = result.riv_bytes;
                         std::fs::write(&output, &bytes).unwrap_or_else(|e| {
                             eprintln!("error writing {:?}: {}", output, e);
                             std::process::exit(1);
                         });
-                        eprintln!("wrote {} bytes to {:?}", bytes.len(), output);
+                        if json {
+                            let json_result = serde_json::json!({
+                                "output_path": output.display().to_string(),
+                                "bytes_written": bytes.len(),
+                                "retries": total_retries,
+                                "attempts": attempts
+                            });
+                            println!("{}", serde_json::to_string_pretty(&json_result).unwrap());
+                        } else {
+                            eprintln!("wrote {} bytes to {:?}", bytes.len(), output);
+                        }
                     }
                     Err(e) => {
                         if let ai::AiError::RepairFailed { ref attempts, .. } = e {
@@ -273,6 +287,7 @@ fn main() {
                 max_retries,
                 baseline,
                 write_baseline,
+                json,
             } => {
                 match ai::run_eval_suite(
                     &suite,
@@ -283,22 +298,34 @@ fn main() {
                     write_baseline.as_deref(),
                 ) {
                     Ok(report) => {
-                        println!("run_id={}", report.run_id);
-                        println!("output_dir={}", report.output_dir);
-                        println!(
-                            "validity_rate={:.3} ({}/{})",
-                            report.validity_rate, report.valid_count, report.case_count
-                        );
-                        println!("average_retries={:.3}", report.average_retries);
-                        println!("style_adherence_rate={:.3}", report.style_adherence_rate);
-                        println!("reproducibility_rate={:.3}", report.reproducibility_rate);
-                        println!("drift_count={}", report.drift_count);
-                        if report.drift_count > 0 {
-                            eprintln!(
-                                "regression drift detected in {} case(s)",
-                                report.drift_count
+                        if json {
+                            let json_str =
+                                serde_json::to_string_pretty(&report).unwrap_or_else(|e| {
+                                    eprintln!("JSON serialization failed: {}", e);
+                                    std::process::exit(1);
+                                });
+                            println!("{}", json_str);
+                            if report.drift_count > 0 {
+                                std::process::exit(1);
+                            }
+                        } else {
+                            println!("run_id={}", report.run_id);
+                            println!("output_dir={}", report.output_dir);
+                            println!(
+                                "validity_rate={:.3} ({}/{})",
+                                report.validity_rate, report.valid_count, report.case_count
                             );
-                            std::process::exit(1);
+                            println!("average_retries={:.3}", report.average_retries);
+                            println!("style_adherence_rate={:.3}", report.style_adherence_rate);
+                            println!("reproducibility_rate={:.3}", report.reproducibility_rate);
+                            println!("drift_count={}", report.drift_count);
+                            if report.drift_count > 0 {
+                                eprintln!(
+                                    "regression drift detected in {} case(s)",
+                                    report.drift_count
+                                );
+                                std::process::exit(1);
+                            }
                         }
                     }
                     Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,7 +265,12 @@ fn main() {
                                 retries: total_retries,
                                 attempts: &attempts,
                             };
-                            println!("{}", serde_json::to_string_pretty(&json_result).unwrap());
+                            let json_str = serde_json::to_string_pretty(&json_result)
+                                .unwrap_or_else(|e| {
+                                    eprintln!("JSON serialization failed: {}", e);
+                                    std::process::exit(1);
+                                });
+                            println!("{}", json_str);
                         } else {
                             eprintln!("wrote {} bytes to {:?}", bytes.len(), output);
                         }
@@ -313,6 +318,10 @@ fn main() {
                                 });
                             println!("{}", json_str);
                             if report.drift_count > 0 {
+                                eprintln!(
+                                    "regression drift detected in {} case(s)",
+                                    report.drift_count
+                                );
                                 std::process::exit(1);
                             }
                         } else {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3902,13 +3902,23 @@ fn test_ai_generate_json_output() {
         json["output_path"].as_str().is_some(),
         "should have output_path"
     );
-    assert!(
-        json["bytes_written"].as_u64().unwrap() > 0,
-        "should have bytes_written"
-    );
+    let bytes_written = json["bytes_written"]
+        .as_u64()
+        .expect("bytes_written should be a u64");
+    assert!(bytes_written > 0, "should have bytes_written");
+    let file_len = std::fs::metadata(&output)
+        .expect("output file should exist")
+        .len();
+    assert_eq!(bytes_written, file_len, "bytes_written should match file size");
     assert!(json["retries"].as_u64().is_some(), "should have retries");
     assert!(
         json["attempts"].as_array().is_some(),
         "should have attempts"
+    );
+    let validate = cargo_run(&["validate", output.to_str().unwrap()]);
+    assert!(
+        validate.status.success(),
+        "validate failed: {}",
+        String::from_utf8_lossy(&validate.stderr)
     );
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3853,3 +3853,25 @@ fn test_multiple_fixtures_validate() {
         );
     }
 }
+
+#[test]
+fn test_ai_generate_json_flag_in_help() {
+    let result = cargo_run(&["ai", "generate", "--help"]);
+    assert!(result.status.success());
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert!(
+        stdout.contains("--json"),
+        "ai generate --help should show --json flag"
+    );
+}
+
+#[test]
+fn test_ai_lab_json_flag_in_help() {
+    let result = cargo_run(&["ai", "lab", "--help"]);
+    assert!(result.status.success());
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert!(
+        stdout.contains("--json"),
+        "ai lab --help should show --json flag"
+    );
+}

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3909,7 +3909,10 @@ fn test_ai_generate_json_output() {
     let file_len = std::fs::metadata(&output)
         .expect("output file should exist")
         .len();
-    assert_eq!(bytes_written, file_len, "bytes_written should match file size");
+    assert_eq!(
+        bytes_written, file_len,
+        "bytes_written should match file size"
+    );
     assert!(json["retries"].as_u64().is_some(), "should have retries");
     assert!(
         json["attempts"].as_array().is_some(),

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3875,3 +3875,40 @@ fn test_ai_lab_json_flag_in_help() {
         "ai lab --help should show --json flag"
     );
 }
+
+#[test]
+fn test_ai_generate_json_output() {
+    let output = temp_output("ai_generate_json_output");
+    cleanup(&output);
+    let _guard = CleanupOnDrop(output.clone());
+
+    let result = cargo_run(&[
+        "ai",
+        "generate",
+        "--template",
+        "bounce",
+        "--json",
+        "-o",
+        output.to_str().unwrap(),
+    ]);
+    assert!(
+        result.status.success(),
+        "ai generate --json failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&result.stdout).expect("--json output should be valid JSON");
+    assert!(
+        json["output_path"].as_str().is_some(),
+        "should have output_path"
+    );
+    assert!(
+        json["bytes_written"].as_u64().unwrap() > 0,
+        "should have bytes_written"
+    );
+    assert!(json["retries"].as_u64().is_some(), "should have retries");
+    assert!(
+        json["attempts"].as_array().is_some(),
+        "should have attempts"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `--json` flag to `ai generate` and `ai lab` CLI commands for structured JSON output (partial fix for #97)
- `ai generate --json` outputs `output_path`, `bytes_written`, `retries`, and `attempts` as JSON to stdout
- `ai lab --json` serializes the full `EvalReport` as JSON to stdout
- Adds `Serialize` derives to `ErrorCategory`, `RepairDiagnostic`, `RepairAttempt`, and `RepairResult` in `src/ai/repair.rs` (with `#[serde(skip)]` on `scene_json` and `riv_bytes` to exclude large blobs)
- Human-readable stderr output is suppressed when `--json` is active for clean piping

## Test plan
- [x] `cargo test` -- all 391 unit + 114 e2e tests pass
- [x] `cargo build --features mcp` -- compiles cleanly
- [x] `cargo run -- ai generate --help` shows `--json` flag
- [x] `cargo run -- ai lab --help` shows `--json` flag
- [x] New e2e tests `test_ai_generate_json_flag_in_help` and `test_ai_lab_json_flag_in_help` verify flag presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --json flag to ai generate and ai lab to emit machine-readable JSON summaries (output path, bytes written, retries, attempts, or diagnostic report).

* **Public API**
  * Repair diagnostics, attempts, and results are now JSON-serializable; large binary/scene fields are excluded from serialization.
  * RepairAttempt added to public exports.

* **Tests**
  * Added end-to-end tests validating --json help and JSON output contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->