### PR TITLE
refactor: one spec walk, one reference resolver, harness read from disk in dev

### DIFF
--- a/demo/riv/manifest.js
+++ b/demo/riv/manifest.js
@@ -1,5 +1,5 @@
 window.__RIVE_FIXTURE_MANIFEST = {
-  "generatedAt": "2026-07-27T12:01:54.784Z",
+  "generatedAt": "2026-07-27T12:21:44.435Z",
   "fixtures": [
     {
       "name": "animation",

--- a/demo/riv/manifest.js
+++ b/demo/riv/manifest.js
@@ -1,5 +1,5 @@
 window.__RIVE_FIXTURE_MANIFEST = {
-  "generatedAt": "2026-07-27T11:22:16.095Z",
+  "generatedAt": "2026-07-27T12:01:54.784Z",
   "fixtures": [
     {
       "name": "animation",

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,6 +1,7 @@
 mod animations;
 mod objects;
 mod parsers;
+mod references;
 pub mod scene;
 pub(crate) mod spec;
 mod state_machines;

--- a/src/builder/objects.rs
+++ b/src/builder/objects.rs
@@ -8,7 +8,7 @@ use crate::objects::constraints::{
     DistanceConstraint, FollowPathConstraint, IKConstraint, RotationConstraint, ScaleConstraint,
     TransformConstraint, TranslationConstraint,
 };
-use crate::objects::core::RiveObject;
+use crate::objects::core::{RiveObject, type_keys};
 use crate::objects::data_binding::{
     self, BindablePropertyArtboard, BindablePropertyBoolean, BindablePropertyColor,
     BindablePropertyEnum, BindablePropertyId, BindablePropertyInteger, BindablePropertyList,
@@ -41,6 +41,7 @@ use super::parsers::{
     parse_color, parse_fill_rule, parse_stroke_cap, parse_stroke_join, parse_trim_mode,
     required_u64_field,
 };
+use super::references::{self, Namespace};
 use super::spec::{ObjectSpec, TextModifierGroupChildSpec};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,6 +64,7 @@ impl FileAssetKind {
 pub(crate) struct SceneContext<'a> {
     pub asset_ids: &'a HashMap<String, (u64, FileAssetKind)>,
     pub asset_kinds: &'a [FileAssetKind],
+    pub type_keys: &'a HashMap<String, u16>,
 }
 
 fn resolve_asset_ordinal(
@@ -71,38 +73,35 @@ fn resolve_asset_ordinal(
     explicit: Option<u64>,
     expected: FileAssetKind,
     ctx: &SceneContext<'_>,
+    fields: (&str, &str),
 ) -> Result<Option<u64>, String> {
-    match (asset_name, explicit) {
-        (Some(_), Some(_)) => Err(format!(
-            "'{owner}' sets both an asset name and an asset index; use one or the other"
-        )),
-        (Some(asset_name), None) => {
-            let (ordinal, kind) = ctx.asset_ids.get(asset_name).copied().ok_or_else(|| {
-                format!("'{owner}' references asset '{asset_name}', which no artboard declares")
-            })?;
-            if kind != expected {
-                return Err(format!(
-                    "'{}' references asset '{}', which is a {}; it must be a {}",
-                    owner,
-                    asset_name,
-                    kind.label(),
-                    expected.label()
-                ));
-            }
-            Ok(Some(ordinal))
-        }
-        (None, Some(ordinal)) => match ctx.asset_kinds.get(ordinal as usize) {
-            Some(kind) if *kind != expected => Err(format!(
-                "'{}' references asset index {}, which is a {}; it must be a {}",
-                owner,
-                ordinal,
+    let lookup = |name: &str| ctx.asset_ids.get(name).map(|(ordinal, _)| *ordinal);
+    let check = |ordinal: u64| match ctx.asset_kinds.get(ordinal as usize) {
+        Some(kind) if *kind != expected => {
+            let subject = match asset_name {
+                Some(name) => format!("asset '{name}'"),
+                None => format!("asset index {ordinal}"),
+            };
+            Err(format!(
+                "references {subject}, which is a {}; it must be a {}",
                 kind.label(),
                 expected.label()
-            )),
-            _ => Ok(Some(ordinal)),
+            ))
+        }
+        _ => Ok(()),
+    };
+    references::resolve(
+        owner,
+        &Namespace {
+            kind: "asset",
+            name_field: fields.0,
+            index_field: fields.1,
+            lookup: &lookup,
+            check: Some(&check),
         },
-        (None, None) => Ok(None),
-    }
+        asset_name,
+        explicit,
+    )
 }
 
 pub(crate) fn file_asset(spec: &ObjectSpec) -> Option<(&str, FileAssetKind)> {
@@ -693,6 +692,7 @@ pub(crate) fn append_object(
                 *asset_id,
                 FileAssetKind::Image,
                 ctx,
+                ("asset", "asset_id"),
             )?
             .unwrap_or(0);
             let mut image = Image::new(name.clone(), parent_id, resolved_asset_id);
@@ -1783,6 +1783,7 @@ pub(crate) fn append_object(
                 *font_asset_id,
                 FileAssetKind::Font,
                 ctx,
+                ("font_asset", "font_asset_id"),
             )? {
                 style.font_asset_id = v;
             }
@@ -1811,27 +1812,35 @@ pub(crate) fn append_object(
             style,
         } => {
             let mut run = TextValueRun::new(name.clone(), parent_id, text.clone());
-            match (style, style_id) {
-                (Some(_), Some(_)) => {
-                    return Err(format!(
-                        "text_value_run '{name}' sets both 'style' and 'style_id'; use one or the other"
-                    ));
-                }
-                (Some(style_name), None) => {
-                    let style_index = name_to_index.get(style_name).ok_or_else(|| {
-                        format!(
-                            "text_value_run '{name}' references text style '{style_name}', which is not defined before it"
-                        )
-                    })?;
-                    run.style_id = style_index
-                        .checked_sub(artboard_start)
-                        .ok_or("internal error: style index precedes artboard start".to_string())?
-                        as u64;
-                }
-                (None, Some(v)) => {
-                    run.style_id = *v;
-                }
-                (None, None) => {}
+            let lookup = |style_name: &str| {
+                name_to_index
+                    .get(style_name)
+                    .and_then(|index| index.checked_sub(artboard_start))
+                    .map(|local| local as u64)
+            };
+            let check = |_: u64| match style
+                .as_deref()
+                .and_then(|style_name| ctx.type_keys.get(style_name))
+            {
+                Some(&type_key) if type_key != type_keys::TEXT_STYLE_PAINT => Err(format!(
+                    "references '{}', which is not a text_style",
+                    style.as_deref().unwrap_or_default()
+                )),
+                _ => Ok(()),
+            };
+            if let Some(resolved) = references::resolve(
+                name,
+                &Namespace {
+                    kind: "text style",
+                    name_field: "style",
+                    index_field: "style_id",
+                    lookup: &lookup,
+                    check: Some(&check),
+                },
+                style.as_deref(),
+                *style_id,
+            )? {
+                run.style_id = resolved;
             }
             objects.push(Box::new(run));
             name_to_index.insert(name.clone(), object_index);

--- a/src/builder/objects.rs
+++ b/src/builder/objects.rs
@@ -64,7 +64,6 @@ impl FileAssetKind {
 pub(crate) struct SceneContext<'a> {
     pub asset_ids: &'a HashMap<String, (u64, FileAssetKind)>,
     pub asset_kinds: &'a [FileAssetKind],
-    pub type_keys: &'a HashMap<String, u16>,
 }
 
 fn resolve_asset_ordinal(
@@ -76,19 +75,23 @@ fn resolve_asset_ordinal(
     fields: (&str, &str),
 ) -> Result<Option<u64>, String> {
     let lookup = |name: &str| ctx.asset_ids.get(name).map(|(ordinal, _)| *ordinal);
-    let check = |ordinal: u64| match ctx.asset_kinds.get(ordinal as usize) {
-        Some(kind) if *kind != expected => {
-            let subject = match asset_name {
-                Some(name) => format!("asset '{name}'"),
-                None => format!("asset index {ordinal}"),
-            };
-            Err(format!(
+    let check = |ordinal: u64| {
+        let subject = match asset_name {
+            Some(name) => format!("asset '{name}'"),
+            None => format!("asset index {ordinal}"),
+        };
+        match ctx.asset_kinds.get(ordinal as usize) {
+            Some(kind) if *kind != expected => Err(format!(
                 "references {subject}, which is a {}; it must be a {}",
                 kind.label(),
                 expected.label()
-            ))
+            )),
+            Some(_) => Ok(()),
+            None => Err(format!(
+                "references {subject}, but the scene declares {} asset(s)",
+                ctx.asset_kinds.len()
+            )),
         }
-        _ => Ok(()),
     };
     references::resolve(
         owner,
@@ -1818,15 +1821,21 @@ pub(crate) fn append_object(
                     .and_then(|index| index.checked_sub(artboard_start))
                     .map(|local| local as u64)
             };
-            let check = |_: u64| match style
-                .as_deref()
-                .and_then(|style_name| ctx.type_keys.get(style_name))
-            {
-                Some(&type_key) if type_key != type_keys::TEXT_STYLE_PAINT => Err(format!(
-                    "references '{}', which is not a text_style",
-                    style.as_deref().unwrap_or_default()
-                )),
-                _ => Ok(()),
+            let check = |local: u64| {
+                let subject = match style.as_deref() {
+                    Some(style_name) => format!("'{style_name}'"),
+                    None => format!("artboard object {local}"),
+                };
+                match objects
+                    .get(artboard_start + local as usize)
+                    .map(|object| object.type_key())
+                {
+                    Some(type_keys::TEXT_STYLE_PAINT) => Ok(()),
+                    Some(_) => Err(format!("references {subject}, which is not a text_style")),
+                    None => Err(format!(
+                        "references {subject}, which is not defined before it"
+                    )),
+                }
             };
             if let Some(resolved) = references::resolve(
                 name,

--- a/src/builder/references.rs
+++ b/src/builder/references.rs
@@ -1,0 +1,117 @@
+pub(crate) struct Namespace<'a> {
+    pub kind: &'a str,
+    pub name_field: &'a str,
+    pub index_field: &'a str,
+    pub lookup: &'a dyn Fn(&str) -> Option<u64>,
+    pub check: Option<&'a dyn Fn(u64) -> Result<(), String>>,
+}
+
+pub(crate) fn resolve(
+    owner: &str,
+    namespace: &Namespace<'_>,
+    name: Option<&str>,
+    index: Option<u64>,
+) -> Result<Option<u64>, String> {
+    let resolved = match (name, index) {
+        (Some(_), Some(_)) => {
+            return Err(format!(
+                "'{}' sets both '{}' and '{}'; use one or the other",
+                owner, namespace.name_field, namespace.index_field
+            ));
+        }
+        (Some(name), None) => Some((*namespace.lookup)(name).ok_or_else(|| {
+            format!(
+                "'{}' references {} '{}', which is not declared",
+                owner, namespace.kind, name
+            )
+        })?),
+        (None, index) => index,
+    };
+    if let (Some(resolved), Some(check)) = (resolved, namespace.check) {
+        check(resolved).map_err(|reason| format!("'{owner}' {reason}"))?;
+    }
+    Ok(resolved)
+}
+
+pub(crate) fn require(
+    owner: &str,
+    namespace: &Namespace<'_>,
+    name: Option<&str>,
+    index: Option<u64>,
+) -> Result<u64, String> {
+    resolve(owner, namespace, name, index)?.ok_or_else(|| {
+        format!(
+            "'{}' needs a '{}' or '{}'",
+            owner, namespace.name_field, namespace.index_field
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn namespace<'a>(
+        lookup: &'a dyn Fn(&str) -> Option<u64>,
+        check: Option<&'a dyn Fn(u64) -> Result<(), String>>,
+    ) -> Namespace<'a> {
+        Namespace {
+            kind: "asset",
+            name_field: "asset",
+            index_field: "asset_id",
+            lookup,
+            check,
+        }
+    }
+
+    #[test]
+    fn resolves_a_name_to_its_index() {
+        let lookup = |name: &str| (name == "Logo").then_some(3);
+        let ns = namespace(&lookup, None);
+        assert_eq!(resolve("Sprite", &ns, Some("Logo"), None), Ok(Some(3)));
+    }
+
+    #[test]
+    fn passes_through_an_explicit_index() {
+        let lookup = |_: &str| None;
+        let ns = namespace(&lookup, None);
+        assert_eq!(resolve("Sprite", &ns, None, Some(7)), Ok(Some(7)));
+        assert_eq!(resolve("Sprite", &ns, None, None), Ok(None));
+    }
+
+    #[test]
+    fn rejects_setting_both_forms() {
+        let lookup = |_: &str| Some(0);
+        let ns = namespace(&lookup, None);
+        let error = resolve("Sprite", &ns, Some("Logo"), Some(1)).unwrap_err();
+        assert!(
+            error.contains("sets both 'asset' and 'asset_id'"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn rejects_an_unknown_name() {
+        let lookup = |_: &str| None;
+        let ns = namespace(&lookup, None);
+        let error = resolve("Sprite", &ns, Some("Missing"), None).unwrap_err();
+        assert!(error.contains("references asset 'Missing'"), "{error}");
+    }
+
+    #[test]
+    fn applies_the_namespace_check_to_both_forms() {
+        let lookup = |name: &str| (name == "Font").then_some(1);
+        let check = |index: u64| {
+            if index == 1 {
+                Err("references a font_asset; it must be an image_asset".to_string())
+            } else {
+                Ok(())
+            }
+        };
+        let ns = namespace(&lookup, Some(&check));
+        let named = resolve("Sprite", &ns, Some("Font"), None).unwrap_err();
+        let numeric = resolve("Sprite", &ns, None, Some(1)).unwrap_err();
+        assert!(named.contains("must be an image_asset"), "{named}");
+        assert_eq!(named, numeric);
+    }
+}

--- a/src/builder/scene.rs
+++ b/src/builder/scene.rs
@@ -154,7 +154,7 @@ pub fn build_scene(
     spec: &SceneSpec,
     base_dir: Option<&Path>,
 ) -> Result<Vec<Box<dyn RiveObject>>, String> {
-    validate_scene_spec(spec)?;
+    let spec_indexes = validate_scene_spec(spec)?;
 
     let artboard_specs = resolve_artboards(spec)?;
     let mut artboard_name_to_index: HashMap<String, usize> = HashMap::new();
@@ -183,12 +183,12 @@ pub fn build_scene(
             }
         }
     }
-    let ctx = SceneContext {
-        asset_ids: &asset_ids,
-        asset_kinds: &asset_kinds,
-    };
-
-    for artboard_spec in &artboard_specs {
+    for (artboard_spec, spec_index) in artboard_specs.iter().zip(&spec_indexes) {
+        let ctx = SceneContext {
+            asset_ids: &asset_ids,
+            asset_kinds: &asset_kinds,
+            type_keys: &spec_index.type_keys,
+        };
         let artboard_start = objects.len();
         let (artboard_width, artboard_height) = resolve_artboard_dimensions(artboard_spec)?;
 

--- a/src/builder/scene.rs
+++ b/src/builder/scene.rs
@@ -154,7 +154,7 @@ pub fn build_scene(
     spec: &SceneSpec,
     base_dir: Option<&Path>,
 ) -> Result<Vec<Box<dyn RiveObject>>, String> {
-    let spec_indexes = validate_scene_spec(spec)?;
+    validate_scene_spec(spec)?;
 
     let artboard_specs = resolve_artboards(spec)?;
     let mut artboard_name_to_index: HashMap<String, usize> = HashMap::new();
@@ -183,11 +183,10 @@ pub fn build_scene(
             }
         }
     }
-    for (artboard_spec, spec_index) in artboard_specs.iter().zip(&spec_indexes) {
+    for artboard_spec in &artboard_specs {
         let ctx = SceneContext {
             asset_ids: &asset_ids,
             asset_kinds: &asset_kinds,
-            type_keys: &spec_index.type_keys,
         };
         let artboard_start = objects.len();
         let (artboard_width, artboard_height) = resolve_artboard_dimensions(artboard_spec)?;

--- a/src/builder/state_machines.rs
+++ b/src/builder/state_machines.rs
@@ -22,6 +22,7 @@ use crate::objects::state_machine::{
 use super::parsers::{
     input_is_trigger, json_value_to_f32, parse_color, parse_condition_op, parse_listener_type,
 };
+use super::references::{self, Namespace};
 use super::spec::{
     BlendState1DChildSpec, BlendStateChildSpec, BlendStateDirectChildSpec, InputSpec,
     ListenerActionSpec, StateMachineComponentSpec, StateMachineSpec, StateSpec,
@@ -281,12 +282,18 @@ pub(crate) fn build_state_machines(
                         input,
                         children,
                     } => {
-                        let input_id = resolve_reference(
+                        let lookup = |name: &str| input_name_to_index.get(name).map(|i| *i as u64);
+                        let input_id = references::require(
                             "blend_state1d",
-                            "input",
+                            &Namespace {
+                                kind: "input",
+                                name_field: "input",
+                                index_field: "input_id",
+                                lookup: &lookup,
+                                check: None,
+                            },
                             input.as_deref(),
                             *input_id,
-                            &input_name_to_index,
                         )?;
                         objects.push(Box::new(BlendState1DInput { input_id }));
                         if let Some(children) = children {
@@ -437,38 +444,24 @@ fn append_blend_state_1d_child(
         animation,
         value,
     } = spec;
-    let animation_id = resolve_reference(
+    let lookup = |name: &str| animation_name_to_index.get(name).map(|i| *i as u64);
+    let animation_id = references::require(
         "blend_animation1_d",
-        "animation",
+        &Namespace {
+            kind: "animation",
+            name_field: "animation",
+            index_field: "animation_id",
+            lookup: &lookup,
+            check: None,
+        },
         animation.as_deref(),
         *animation_id,
-        animation_name_to_index,
     )?;
     objects.push(Box::new(BlendAnimation1D {
         animation_id,
         value: value.unwrap_or(0.0),
     }));
     Ok(())
-}
-
-fn resolve_reference(
-    owner: &str,
-    kind: &str,
-    name: Option<&str>,
-    explicit: Option<u64>,
-    index: &HashMap<String, usize>,
-) -> Result<u64, String> {
-    match (name, explicit) {
-        (Some(_), Some(_)) => Err(format!(
-            "{owner} sets both '{kind}' and '{kind}_id'; use one or the other"
-        )),
-        (Some(name), None) => index
-            .get(name)
-            .map(|resolved| *resolved as u64)
-            .ok_or_else(|| format!("{owner} references {kind} '{name}', which is not defined")),
-        (None, Some(explicit)) => Ok(explicit),
-        (None, None) => Err(format!("{owner} needs a '{kind}' or '{kind}_id'")),
-    }
 }
 
 fn append_transition_child(

--- a/src/builder/validation.rs
+++ b/src/builder/validation.rs
@@ -16,7 +16,7 @@ use super::spec::{
     TextModifierGroupChildSpec, TransitionChildSpec,
 };
 
-pub(crate) fn validate_scene_spec(spec: &SceneSpec) -> Result<(), String> {
+pub(crate) fn validate_scene_spec(spec: &SceneSpec) -> Result<Vec<SpecIndex>, String> {
     if spec.scene_format_version != SCENE_FORMAT_VERSION {
         return Err(format!(
             "unsupported scene_format_version {} (expected {})",
@@ -27,12 +27,13 @@ pub(crate) fn validate_scene_spec(spec: &SceneSpec) -> Result<(), String> {
     let artboard_specs = super::scene::resolve_artboards(spec)?;
 
     let mut artboard_names: HashSet<String> = HashSet::new();
+    let mut indexes: Vec<SpecIndex> = Vec::new();
     for artboard_spec in &artboard_specs {
         if artboard_names.contains(&artboard_spec.name) {
             return Err(format!("duplicate artboard name '{}'", artboard_spec.name));
         }
         artboard_names.insert(artboard_spec.name.clone());
-        validate_artboard_spec(artboard_spec)?;
+        indexes.push(validate_artboard_spec(artboard_spec)?);
     }
 
     let mut artboard_deps: HashMap<String, Vec<String>> = HashMap::new();
@@ -44,10 +45,10 @@ pub(crate) fn validate_scene_spec(spec: &SceneSpec) -> Result<(), String> {
     }
     detect_artboard_cycles(&artboard_deps)?;
 
-    Ok(())
+    Ok(indexes)
 }
 
-pub(crate) fn validate_artboard_spec(artboard_spec: &ArtboardSpec) -> Result<(), String> {
+pub(crate) fn validate_artboard_spec(artboard_spec: &ArtboardSpec) -> Result<SpecIndex, String> {
     if artboard_spec.width < 0.0 {
         return Err(format!(
             "artboard '{}' width must be non-negative",
@@ -64,13 +65,12 @@ pub(crate) fn validate_artboard_spec(artboard_spec: &ArtboardSpec) -> Result<(),
     resolve_artboard_dimensions(artboard_spec)?;
 
     let mut object_names: HashSet<String> = HashSet::new();
-    let mut object_type_keys: HashMap<String, u16> = HashMap::new();
-    let mut ambiguous_names: HashSet<String> = HashSet::new();
     for child in &artboard_spec.children {
         validate_object_spec(child, &mut object_names, &ParentKind::Artboard)?;
-        collect_ambiguous_names(child, &mut HashSet::new(), &mut ambiguous_names);
-        collect_object_type_key(child, &mut object_type_keys);
     }
+    let spec_index = SpecIndex::build(&artboard_spec.children);
+    let object_type_keys = &spec_index.type_keys;
+    let ambiguous_names = &spec_index.ambiguous;
     validate_image_asset_references(&artboard_spec.children)?;
 
     let mut animation_names: HashSet<String> = HashSet::new();
@@ -479,7 +479,7 @@ pub(crate) fn validate_artboard_spec(artboard_spec: &ArtboardSpec) -> Result<(),
         }
     }
 
-    Ok(())
+    Ok(spec_index)
 }
 
 pub(crate) fn validate_object_spec(
@@ -1582,283 +1582,280 @@ pub(crate) fn validate_object_spec(
     Ok(())
 }
 
-fn collect_ambiguous_names(
-    spec: &ObjectSpec,
-    seen: &mut HashSet<String>,
-    ambiguous: &mut HashSet<String>,
-) {
-    let mut names: HashMap<String, u16> = HashMap::new();
-    collect_object_type_key_named(spec, &mut names, seen, ambiguous);
+#[derive(Default)]
+pub(crate) struct SpecIndex {
+    pub type_keys: HashMap<String, u16>,
+    pub ambiguous: HashSet<String>,
+    pub assets: Vec<(String, u16)>,
 }
 
-fn collect_object_type_key_named(
-    spec: &ObjectSpec,
-    names: &mut HashMap<String, u16>,
-    seen: &mut HashSet<String>,
-    ambiguous: &mut HashSet<String>,
-) {
-    let before: HashSet<String> = names.keys().cloned().collect();
-    collect_object_type_key(spec, names);
-    for name in names.keys() {
-        if before.contains(name) {
-            continue;
+impl SpecIndex {
+    pub fn build(children: &[ObjectSpec]) -> SpecIndex {
+        let mut index = SpecIndex::default();
+        for child in children {
+            collect_object_type_key(child, &mut |name: &str, type_key: u16| {
+                if matches!(
+                    type_key,
+                    type_keys::IMAGE_ASSET | type_keys::FONT_ASSET | type_keys::AUDIO_ASSET
+                ) {
+                    index.assets.push((name.to_string(), type_key));
+                }
+                if index.type_keys.insert(name.to_string(), type_key).is_some() {
+                    index.ambiguous.insert(name.to_string());
+                }
+            });
         }
-        if !seen.insert(name.clone()) {
-            ambiguous.insert(name.clone());
-        }
+        index
     }
 }
 
-pub(crate) fn collect_object_type_key(
-    spec: &ObjectSpec,
-    object_type_keys: &mut HashMap<String, u16>,
-) {
+pub(crate) fn collect_object_type_key(spec: &ObjectSpec, visit: &mut dyn FnMut(&str, u16)) {
     match spec {
         ObjectSpec::Shape { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SHAPE);
+            visit(name, type_keys::SHAPE);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::Solo { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SOLO);
+            visit(name, type_keys::SOLO);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::Ellipse { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::ELLIPSE);
+            visit(name, type_keys::ELLIPSE);
         }
         ObjectSpec::Rectangle { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::RECTANGLE);
+            visit(name, type_keys::RECTANGLE);
         }
         ObjectSpec::Triangle { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TRIANGLE);
+            visit(name, type_keys::TRIANGLE);
         }
         ObjectSpec::Polygon { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::POLYGON);
+            visit(name, type_keys::POLYGON);
         }
         ObjectSpec::Star { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::STAR);
+            visit(name, type_keys::STAR);
         }
         ObjectSpec::Fill { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::FILL);
+            visit(name, type_keys::FILL);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::Stroke { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::STROKE);
+            visit(name, type_keys::STROKE);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::SolidColor { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SOLID_COLOR);
+            visit(name, type_keys::SOLID_COLOR);
         }
         ObjectSpec::LinearGradient { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::LINEAR_GRADIENT);
+            visit(name, type_keys::LINEAR_GRADIENT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::RadialGradient { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::RADIAL_GRADIENT);
+            visit(name, type_keys::RADIAL_GRADIENT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::GradientStop { name, .. } => {
             if let Some(name) = name {
-                object_type_keys.insert(name.clone(), type_keys::GRADIENT_STOP);
+                visit(name, type_keys::GRADIENT_STOP);
             }
         }
         ObjectSpec::Node { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NODE);
+            visit(name, type_keys::NODE);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::Image { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::IMAGE);
+            visit(name, type_keys::IMAGE);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::Path { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::PATH);
+            visit(name, type_keys::PATH);
         }
         ObjectSpec::PointsPath { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::POINTS_PATH);
+            visit(name, type_keys::POINTS_PATH);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::StraightVertex { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::STRAIGHT_VERTEX);
+            visit(name, type_keys::STRAIGHT_VERTEX);
         }
         ObjectSpec::CubicMirroredVertex { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUBIC_MIRRORED_VERTEX);
+            visit(name, type_keys::CUBIC_MIRRORED_VERTEX);
         }
         ObjectSpec::CubicDetachedVertex { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUBIC_DETACHED_VERTEX);
+            visit(name, type_keys::CUBIC_DETACHED_VERTEX);
         }
         ObjectSpec::CubicAsymmetricVertex { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUBIC_ASYMMETRIC_VERTEX);
+            visit(name, type_keys::CUBIC_ASYMMETRIC_VERTEX);
         }
         ObjectSpec::TrimPath { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TRIM_PATH);
+            visit(name, type_keys::TRIM_PATH);
         }
         ObjectSpec::NestedArtboard { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NESTED_ARTBOARD);
+            visit(name, type_keys::NESTED_ARTBOARD);
         }
         ObjectSpec::NestedStateMachine { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NESTED_STATE_MACHINE);
+            visit(name, type_keys::NESTED_STATE_MACHINE);
         }
         ObjectSpec::NestedSimpleAnimation { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NESTED_SIMPLE_ANIMATION);
+            visit(name, type_keys::NESTED_SIMPLE_ANIMATION);
         }
         ObjectSpec::Event { name, children } => {
-            object_type_keys.insert(name.clone(), type_keys::EVENT);
+            visit(name, type_keys::EVENT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::Bone { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::BONE);
+            visit(name, type_keys::BONE);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::RootBone { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::ROOT_BONE);
+            visit(name, type_keys::ROOT_BONE);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::Skin { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SKIN);
+            visit(name, type_keys::SKIN);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::Tendon { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TENDON);
+            visit(name, type_keys::TENDON);
         }
         ObjectSpec::Weight { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::WEIGHT);
+            visit(name, type_keys::WEIGHT);
         }
         ObjectSpec::CubicWeight { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUBIC_WEIGHT);
+            visit(name, type_keys::CUBIC_WEIGHT);
         }
         ObjectSpec::IkConstraint { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::IK_CONSTRAINT);
+            visit(name, type_keys::IK_CONSTRAINT);
         }
         ObjectSpec::DistanceConstraint { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DISTANCE_CONSTRAINT);
+            visit(name, type_keys::DISTANCE_CONSTRAINT);
         }
         ObjectSpec::TransformConstraint { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TRANSFORM_CONSTRAINT);
+            visit(name, type_keys::TRANSFORM_CONSTRAINT);
         }
         ObjectSpec::TranslationConstraint { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TRANSLATION_CONSTRAINT);
+            visit(name, type_keys::TRANSLATION_CONSTRAINT);
         }
         ObjectSpec::ScaleConstraint { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCALE_CONSTRAINT);
+            visit(name, type_keys::SCALE_CONSTRAINT);
         }
         ObjectSpec::RotationConstraint { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::ROTATION_CONSTRAINT);
+            visit(name, type_keys::ROTATION_CONSTRAINT);
         }
         ObjectSpec::FollowPathConstraint { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::FOLLOW_PATH_CONSTRAINT);
+            visit(name, type_keys::FOLLOW_PATH_CONSTRAINT);
         }
         ObjectSpec::ClippingShape { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CLIPPING_SHAPE);
+            visit(name, type_keys::CLIPPING_SHAPE);
         }
         ObjectSpec::DrawRules { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DRAW_RULES);
+            visit(name, type_keys::DRAW_RULES);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::DrawTarget { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DRAW_TARGET);
+            visit(name, type_keys::DRAW_TARGET);
         }
         ObjectSpec::Joystick { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::JOYSTICK);
+            visit(name, type_keys::JOYSTICK);
         }
         ObjectSpec::Text { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TEXT);
+            visit(name, type_keys::TEXT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::TextStyle { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TEXT_STYLE_PAINT);
+            visit(name, type_keys::TEXT_STYLE_PAINT);
         }
         ObjectSpec::TextValueRun { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TEXT_VALUE_RUN);
+            visit(name, type_keys::TEXT_VALUE_RUN);
         }
         ObjectSpec::ImageAsset { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::IMAGE_ASSET);
+            visit(name, type_keys::IMAGE_ASSET);
         }
         ObjectSpec::FontAsset { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::FONT_ASSET);
+            visit(name, type_keys::FONT_ASSET);
         }
         ObjectSpec::AudioAsset { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::AUDIO_ASSET);
+            visit(name, type_keys::AUDIO_ASSET);
         }
         ObjectSpec::LayoutComponent { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::LAYOUT_COMPONENT);
+            visit(name, type_keys::LAYOUT_COMPONENT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::LayoutComponentStyle { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::LAYOUT_COMPONENT_STYLE);
+            visit(name, type_keys::LAYOUT_COMPONENT_STYLE);
         }
         ObjectSpec::ViewModel { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::VIEW_MODEL);
+            visit(name, type_keys::VIEW_MODEL);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::ViewModelProperty { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::VIEW_MODEL_PROPERTY);
+            visit(name, type_keys::VIEW_MODEL_PROPERTY);
         }
         ObjectSpec::DataBind { .. } => {}
         ObjectSpec::ViewModelInstance { .. }
@@ -1875,223 +1872,223 @@ pub(crate) fn collect_object_type_key(
         | ObjectSpec::TextVariationModifier { .. }
         | ObjectSpec::TextStyleFeature { .. } => {}
         ObjectSpec::TextModifierGroup { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TEXT_MODIFIER_GROUP);
+            visit(name, type_keys::TEXT_MODIFIER_GROUP);
         }
         ObjectSpec::Folder { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::FOLDER);
+            visit(name, type_keys::FOLDER);
         }
         ObjectSpec::LayeredAsset { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::LAYERED_ASSET);
+            visit(name, type_keys::LAYERED_ASSET);
         }
         ObjectSpec::LayerImageAsset { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::LAYER_IMAGE_ASSET);
+            visit(name, type_keys::LAYER_IMAGE_ASSET);
         }
         ObjectSpec::SVGAsset { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SVG_ASSET);
+            visit(name, type_keys::SVG_ASSET);
         }
         ObjectSpec::LottieAsset { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::LOTTIE_ASSET);
+            visit(name, type_keys::LOTTIE_ASSET);
         }
         ObjectSpec::ExportAudio { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::EXPORT_AUDIO);
+            visit(name, type_keys::EXPORT_AUDIO);
         }
         ObjectSpec::ScriptAsset { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPT_ASSET);
+            visit(name, type_keys::SCRIPT_ASSET);
         }
         ObjectSpec::BlobAsset { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::BLOB_ASSET);
+            visit(name, type_keys::BLOB_ASSET);
         }
         ObjectSpec::DashPath { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DASH_PATH);
+            visit(name, type_keys::DASH_PATH);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::Dash { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DASH);
+            visit(name, type_keys::DASH);
         }
         ObjectSpec::Feather { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::FEATHER);
+            visit(name, type_keys::FEATHER);
         }
         ObjectSpec::OpenUrlEvent { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::OPEN_URL_EVENT);
+            visit(name, type_keys::OPEN_URL_EVENT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::AudioEvent { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::AUDIO_EVENT);
+            visit(name, type_keys::AUDIO_EVENT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::CustomPropertyNumber { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUSTOM_PROPERTY_NUMBER);
+            visit(name, type_keys::CUSTOM_PROPERTY_NUMBER);
         }
         ObjectSpec::CustomPropertyBoolean { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUSTOM_PROPERTY_BOOLEAN);
+            visit(name, type_keys::CUSTOM_PROPERTY_BOOLEAN);
         }
         ObjectSpec::CustomPropertyString { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUSTOM_PROPERTY_STRING);
+            visit(name, type_keys::CUSTOM_PROPERTY_STRING);
         }
         ObjectSpec::CustomPropertyColor { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUSTOM_PROPERTY_COLOR);
+            visit(name, type_keys::CUSTOM_PROPERTY_COLOR);
         }
         ObjectSpec::CustomPropertyTrigger { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUSTOM_PROPERTY_TRIGGER);
+            visit(name, type_keys::CUSTOM_PROPERTY_TRIGGER);
         }
         ObjectSpec::CustomPropertyEnum { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUSTOM_PROPERTY_ENUM);
+            visit(name, type_keys::CUSTOM_PROPERTY_ENUM);
         }
         ObjectSpec::CustomPropertyGroup { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CUSTOM_PROPERTY_GROUP);
+            visit(name, type_keys::CUSTOM_PROPERTY_GROUP);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::TargetEffect { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TARGET_EFFECT);
+            visit(name, type_keys::TARGET_EFFECT);
         }
         ObjectSpec::GroupEffect { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::GROUP_EFFECT);
+            visit(name, type_keys::GROUP_EFFECT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::ListPath { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::LIST_PATH);
+            visit(name, type_keys::LIST_PATH);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::PointsCommonPath { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::POINTS_COMMON_PATH);
+            visit(name, type_keys::POINTS_COMMON_PATH);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::Guide { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::GUIDE);
+            visit(name, type_keys::GUIDE);
         }
         ObjectSpec::ArtboardComponentList { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::ARTBOARD_COMPONENT_LIST);
+            visit(name, type_keys::ARTBOARD_COMPONENT_LIST);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::ArtboardComponentListOverride { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::ARTBOARD_COMPONENT_LIST_OVERRIDE);
+            visit(name, type_keys::ARTBOARD_COMPONENT_LIST_OVERRIDE);
         }
         ObjectSpec::ArtboardListMapRule { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::ARTBOARD_LIST_MAP_RULE);
+            visit(name, type_keys::ARTBOARD_LIST_MAP_RULE);
         }
         ObjectSpec::ForegroundLayoutDrawable { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::FOREGROUND_LAYOUT_DRAWABLE);
+            visit(name, type_keys::FOREGROUND_LAYOUT_DRAWABLE);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::ClampedScrollPhysics { .. } => {}
         ObjectSpec::ElasticScrollPhysics { .. } => {}
         ObjectSpec::Mesh { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::MESH);
+            visit(name, type_keys::MESH);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::MeshVertex { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::MESH_VERTEX);
+            visit(name, type_keys::MESH_VERTEX);
         }
         ObjectSpec::ContourMeshVertex { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::CONTOUR_MESH_VERTEX);
+            visit(name, type_keys::CONTOUR_MESH_VERTEX);
         }
         ObjectSpec::ForcedEdge { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::FORCED_EDGE);
+            visit(name, type_keys::FORCED_EDGE);
         }
         ObjectSpec::NestedLinearAnimation { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NESTED_LINEAR_ANIMATION);
+            visit(name, type_keys::NESTED_LINEAR_ANIMATION);
         }
         ObjectSpec::NestedRemapAnimation { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NESTED_REMAP_ANIMATION);
+            visit(name, type_keys::NESTED_REMAP_ANIMATION);
         }
         ObjectSpec::NestedTrigger { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NESTED_TRIGGER);
+            visit(name, type_keys::NESTED_TRIGGER);
         }
         ObjectSpec::NestedBool { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NESTED_BOOL);
+            visit(name, type_keys::NESTED_BOOL);
         }
         ObjectSpec::NestedNumber { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NESTED_NUMBER);
+            visit(name, type_keys::NESTED_NUMBER);
         }
         ObjectSpec::NestedArtboardLeaf { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NESTED_ARTBOARD_LEAF);
+            visit(name, type_keys::NESTED_ARTBOARD_LEAF);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::NestedArtboardLayout { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NESTED_ARTBOARD_LAYOUT);
+            visit(name, type_keys::NESTED_ARTBOARD_LAYOUT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::DraggableConstraint { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DRAGGABLE_CONSTRAINT);
+            visit(name, type_keys::DRAGGABLE_CONSTRAINT);
         }
         ObjectSpec::ScrollConstraint { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCROLL_CONSTRAINT);
+            visit(name, type_keys::SCROLL_CONSTRAINT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::ScrollBarConstraint { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCROLL_BAR_CONSTRAINT);
+            visit(name, type_keys::SCROLL_BAR_CONSTRAINT);
         }
         ObjectSpec::ListFollowPathConstraint { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::LIST_FOLLOW_PATH_CONSTRAINT);
+            visit(name, type_keys::LIST_FOLLOW_PATH_CONSTRAINT);
         }
         ObjectSpec::NSlicerTileMode { .. } => {}
         ObjectSpec::NSlicer { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NSLICER);
+            visit(name, type_keys::NSLICER);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::AxisY { .. } => {}
         ObjectSpec::AxisX { .. } => {}
         ObjectSpec::NSlicedNode { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::NSLICED_NODE);
+            visit(name, type_keys::NSLICED_NODE);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
@@ -2109,35 +2106,35 @@ pub(crate) fn collect_object_type_key(
         | ObjectSpec::ViewModelPropertyArtboard { name, children, .. }
         | ObjectSpec::ViewModelPropertySymbol { name, children, .. }
         | ObjectSpec::ViewModelPropertySymbolListIndex { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::VIEW_MODEL_PROPERTY);
+            visit(name, type_keys::VIEW_MODEL_PROPERTY);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::DataEnum { name, children } | ObjectSpec::DataEnumCustom { name, children } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_ENUM);
+            visit(name, type_keys::DATA_ENUM);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::DataEnumSystem { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_ENUM_SYSTEM);
+            visit(name, type_keys::DATA_ENUM_SYSTEM);
         }
         ObjectSpec::TextTargetModifier { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TEXT_TARGET_MODIFIER);
+            visit(name, type_keys::TEXT_TARGET_MODIFIER);
         }
         ObjectSpec::TextFollowPathModifier { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TEXT_FOLLOW_PATH_MODIFIER);
+            visit(name, type_keys::TEXT_FOLLOW_PATH_MODIFIER);
         }
         ObjectSpec::TextInput { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::TEXT_INPUT);
+            visit(name, type_keys::TEXT_INPUT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
@@ -2146,10 +2143,10 @@ pub(crate) fn collect_object_type_key(
         | ObjectSpec::TextInputText { name, children }
         | ObjectSpec::TextInputSelection { name, children }
         | ObjectSpec::TextInputSelectedText { name, children } => {
-            object_type_keys.insert(name.clone(), type_keys::TEXT);
+            visit(name, type_keys::TEXT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
@@ -2182,111 +2179,111 @@ pub(crate) fn collect_object_type_key(
         | ObjectSpec::ScriptedListenerAction { .. }
         | ObjectSpec::ScriptedTransitionCondition { .. } => {}
         ObjectSpec::DataConverterRounder { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_ROUNDER);
+            visit(name, type_keys::DATA_CONVERTER_ROUNDER);
         }
         ObjectSpec::DataConverterToString { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_TO_STRING);
+            visit(name, type_keys::DATA_CONVERTER_TO_STRING);
         }
         ObjectSpec::DataConverterToNumber { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_TO_NUMBER);
+            visit(name, type_keys::DATA_CONVERTER_TO_NUMBER);
         }
         ObjectSpec::DataConverterGroup { name, children } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_GROUP);
+            visit(name, type_keys::DATA_CONVERTER_GROUP);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::DataConverterOperationValue { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_OPERATION_VALUE);
+            visit(name, type_keys::DATA_CONVERTER_OPERATION_VALUE);
         }
         ObjectSpec::DataConverterTrigger { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_TRIGGER);
+            visit(name, type_keys::DATA_CONVERTER_TRIGGER);
         }
         ObjectSpec::DataConverterOperationViewModel { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_OPERATION_VIEW_MODEL);
+            visit(name, type_keys::DATA_CONVERTER_OPERATION_VIEW_MODEL);
         }
         ObjectSpec::DataConverterStringPad { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_STRING_PAD);
+            visit(name, type_keys::DATA_CONVERTER_STRING_PAD);
         }
         ObjectSpec::DataConverterStringRemoveZeros { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_STRING_REMOVE_ZEROS);
+            visit(name, type_keys::DATA_CONVERTER_STRING_REMOVE_ZEROS);
         }
         ObjectSpec::DataConverterStringTrim { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_STRING_TRIM);
+            visit(name, type_keys::DATA_CONVERTER_STRING_TRIM);
         }
         ObjectSpec::DataConverterInterpolator { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_INTERPOLATOR);
+            visit(name, type_keys::DATA_CONVERTER_INTERPOLATOR);
         }
         ObjectSpec::DataConverterBooleanNegate { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_BOOLEAN_NEGATE);
+            visit(name, type_keys::DATA_CONVERTER_BOOLEAN_NEGATE);
         }
         ObjectSpec::DataConverterRangeMapper { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_RANGE_MAPPER);
+            visit(name, type_keys::DATA_CONVERTER_RANGE_MAPPER);
         }
         ObjectSpec::DataConverterFormula { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_FORMULA);
+            visit(name, type_keys::DATA_CONVERTER_FORMULA);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::DataConverterSystemDegsToRads { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_SYSTEM_DEGS_TO_RADS);
+            visit(name, type_keys::DATA_CONVERTER_SYSTEM_DEGS_TO_RADS);
         }
         ObjectSpec::DataConverterSystemNormalizer { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_SYSTEM_NORMALIZER);
+            visit(name, type_keys::DATA_CONVERTER_SYSTEM_NORMALIZER);
         }
         ObjectSpec::DataConverterNumberToList { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_NUMBER_TO_LIST);
+            visit(name, type_keys::DATA_CONVERTER_NUMBER_TO_LIST);
         }
         ObjectSpec::DataConverterListToLength { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::DATA_CONVERTER_LIST_TO_LENGTH);
+            visit(name, type_keys::DATA_CONVERTER_LIST_TO_LENGTH);
         }
         ObjectSpec::ScriptedDrawable { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPTED_DRAWABLE);
+            visit(name, type_keys::SCRIPTED_DRAWABLE);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::ScriptedDataConverter { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPTED_DATA_CONVERTER);
+            visit(name, type_keys::SCRIPTED_DATA_CONVERTER);
         }
         ObjectSpec::ScriptedLayout { name, children, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPTED_LAYOUT);
+            visit(name, type_keys::SCRIPTED_LAYOUT);
             if let Some(children) = children {
                 for child in children {
-                    collect_object_type_key(child, object_type_keys);
+                    collect_object_type_key(child, visit);
                 }
             }
         }
         ObjectSpec::ScriptedPathEffect { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPTED_PATH_EFFECT);
+            visit(name, type_keys::SCRIPTED_PATH_EFFECT);
         }
         ObjectSpec::ScriptInputNumber { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPT_INPUT_NUMBER);
+            visit(name, type_keys::SCRIPT_INPUT_NUMBER);
         }
         ObjectSpec::ScriptInputViewModelProperty { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPT_INPUT_VIEW_MODEL_PROPERTY);
+            visit(name, type_keys::SCRIPT_INPUT_VIEW_MODEL_PROPERTY);
         }
         ObjectSpec::ScriptInputTrigger { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPT_INPUT_TRIGGER);
+            visit(name, type_keys::SCRIPT_INPUT_TRIGGER);
         }
         ObjectSpec::ScriptInputArtboard { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPT_INPUT_ARTBOARD);
+            visit(name, type_keys::SCRIPT_INPUT_ARTBOARD);
         }
         ObjectSpec::ScriptInputColor { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPT_INPUT_COLOR);
+            visit(name, type_keys::SCRIPT_INPUT_COLOR);
         }
         ObjectSpec::ScriptInputString { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPT_INPUT_STRING);
+            visit(name, type_keys::SCRIPT_INPUT_STRING);
         }
         ObjectSpec::ScriptInputBoolean { name, .. } => {
-            object_type_keys.insert(name.clone(), type_keys::SCRIPT_INPUT_BOOLEAN);
+            visit(name, type_keys::SCRIPT_INPUT_BOOLEAN);
         }
     }
 }

--- a/src/builder/validation.rs
+++ b/src/builder/validation.rs
@@ -16,7 +16,7 @@ use super::spec::{
     TextModifierGroupChildSpec, TransitionChildSpec,
 };
 
-pub(crate) fn validate_scene_spec(spec: &SceneSpec) -> Result<Vec<SpecIndex>, String> {
+pub(crate) fn validate_scene_spec(spec: &SceneSpec) -> Result<(), String> {
     if spec.scene_format_version != SCENE_FORMAT_VERSION {
         return Err(format!(
             "unsupported scene_format_version {} (expected {})",
@@ -27,13 +27,12 @@ pub(crate) fn validate_scene_spec(spec: &SceneSpec) -> Result<Vec<SpecIndex>, St
     let artboard_specs = super::scene::resolve_artboards(spec)?;
 
     let mut artboard_names: HashSet<String> = HashSet::new();
-    let mut indexes: Vec<SpecIndex> = Vec::new();
     for artboard_spec in &artboard_specs {
         if artboard_names.contains(&artboard_spec.name) {
             return Err(format!("duplicate artboard name '{}'", artboard_spec.name));
         }
         artboard_names.insert(artboard_spec.name.clone());
-        indexes.push(validate_artboard_spec(artboard_spec)?);
+        validate_artboard_spec(artboard_spec)?;
     }
 
     let mut artboard_deps: HashMap<String, Vec<String>> = HashMap::new();
@@ -45,10 +44,10 @@ pub(crate) fn validate_scene_spec(spec: &SceneSpec) -> Result<Vec<SpecIndex>, St
     }
     detect_artboard_cycles(&artboard_deps)?;
 
-    Ok(indexes)
+    Ok(())
 }
 
-pub(crate) fn validate_artboard_spec(artboard_spec: &ArtboardSpec) -> Result<SpecIndex, String> {
+pub(crate) fn validate_artboard_spec(artboard_spec: &ArtboardSpec) -> Result<(), String> {
     if artboard_spec.width < 0.0 {
         return Err(format!(
             "artboard '{}' width must be non-negative",
@@ -479,7 +478,7 @@ pub(crate) fn validate_artboard_spec(artboard_spec: &ArtboardSpec) -> Result<Spe
         }
     }
 
-    Ok(spec_index)
+    Ok(())
 }
 
 pub(crate) fn validate_object_spec(

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -11,6 +11,20 @@ use thiserror::Error;
 const RIVE_JS: &[u8] = include_bytes!("../../assets/rive.js");
 const RIVE_WASM: &[u8] = include_bytes!("../../assets/rive.wasm");
 const HARNESS: &[u8] = include_bytes!("../../assets/render-harness.html");
+const HARNESS_SOURCE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/assets/render-harness.html");
+const HARNESS_OVERRIDE_VAR: &str = "RIVE_HARNESS";
+
+fn harness() -> Vec<u8> {
+    let candidate = match std::env::var_os(HARNESS_OVERRIDE_VAR) {
+        Some(path) => PathBuf::from(path),
+        None if cfg!(debug_assertions) => PathBuf::from(HARNESS_SOURCE),
+        None => return HARNESS.to_vec(),
+    };
+    match fs::read(&candidate) {
+        Ok(bytes) => bytes,
+        Err(_) => HARNESS.to_vec(),
+    }
+}
 
 const READY_POLL_ATTEMPTS: u32 = 300;
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -171,7 +185,7 @@ pub fn render(options: &RenderOptions) -> Result<RenderManifest, RenderError> {
         .as_deref()
         .map(parse_background)
         .transpose()?;
-    let server = server::AssetServer::start(HARNESS, RIVE_JS, RIVE_WASM, options.riv.clone())?;
+    let server = server::AssetServer::start(harness(), RIVE_JS, RIVE_WASM, options.riv.clone())?;
     let browser_path = chrome::discover(options.browser.as_deref())?;
     let mut browser = chrome::Chrome::launch(&browser_path, options.scale)?;
     let session = browser.session.clone();

--- a/src/render/server.rs
+++ b/src/render/server.rs
@@ -20,7 +20,7 @@ pub struct AssetServer {
 }
 
 struct Assets {
-    html: &'static [u8],
+    html: Vec<u8>,
     js: &'static [u8],
     wasm: &'static [u8],
     scene: Vec<u8>,
@@ -28,7 +28,7 @@ struct Assets {
 
 impl AssetServer {
     pub fn start(
-        html: &'static [u8],
+        html: impl Into<Vec<u8>>,
         js: &'static [u8],
         wasm: &'static [u8],
         scene: Vec<u8>,
@@ -39,7 +39,7 @@ impl AssetServer {
         let stop = Arc::new(AtomicBool::new(false));
         let flag = stop.clone();
         let assets = Arc::new(Assets {
-            html,
+            html: html.into(),
             js,
             wasm,
             scene,
@@ -97,7 +97,7 @@ fn serve(mut stream: TcpStream, assets: &Assets) {
         .unwrap_or("");
     let route = path.split('?').next().unwrap_or(path);
     let (status, content_type, body): (&str, &str, &[u8]) = match route {
-        "/" | "/index.html" => ("200 OK", "text/html; charset=utf-8", assets.html),
+        "/" | "/index.html" => ("200 OK", "text/html; charset=utf-8", assets.html.as_slice()),
         "/rive.js" => ("200 OK", "application/javascript", assets.js),
         "/rive.wasm" => ("200 OK", "application/wasm", assets.wasm),
         "/scene.riv" => ("200 OK", "application/octet-stream", &assets.scene),

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5070,17 +5070,45 @@ fn test_scheduled_input_failures_fail_the_render() {
 }
 
 #[test]
-fn test_style_reference_must_name_a_text_style() {
-    let stderr = generate_scene_expecting_failure(
+fn test_style_reference_must_resolve_to_a_text_style() {
+    let named = generate_scene_expecting_failure(
         r#"{"scene_format_version":1,"artboard":{"name":"A","width":200,"height":200,"children":[
            {"type":"node","name":"Decoy","x":10,"y":10},
            {"type":"text","name":"T","align_value":1,"sizing_value":0,"children":[
              {"type":"text_style","name":"S","font_size":20},
              {"type":"text_value_run","name":"R","text":"hi","style":"Decoy"}]}]}}"#,
-        "style_kind",
+        "style_kind_named",
     );
     assert!(
-        stderr.contains("references 'Decoy', which is not a text_style"),
+        named.contains("references 'Decoy', which is not a text_style"),
+        "unexpected error: {named}"
+    );
+
+    let numeric = generate_scene_expecting_failure(
+        r#"{"scene_format_version":1,"artboard":{"name":"A","width":200,"height":200,"children":[
+           {"type":"node","name":"Decoy","x":10,"y":10},
+           {"type":"text","name":"T","align_value":1,"sizing_value":0,"children":[
+             {"type":"text_style","name":"S","font_size":20},
+             {"type":"text_value_run","name":"R","text":"hi","style_id":0}]}]}}"#,
+        "style_kind_numeric",
+    );
+    assert!(
+        numeric.contains("references artboard object 0, which is not a text_style"),
+        "unexpected error: {numeric}"
+    );
+}
+
+#[test]
+fn test_asset_reference_index_must_exist() {
+    let stderr = generate_scene_expecting_failure(
+        r#"{"scene_format_version":1,"artboard":{"name":"A","width":100,"height":100,"children":[
+           {"type":"font_asset","name":"F"},
+           {"type":"text","name":"T","align_value":1,"sizing_value":0,"children":[
+             {"type":"text_style","name":"S","font_size":20,"font_asset_id":9}]}]}}"#,
+        "asset_bounds",
+    );
+    assert!(
+        stderr.contains("but the scene declares 1 asset(s)"),
         "unexpected error: {stderr}"
     );
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5068,3 +5068,19 @@ fn test_scheduled_input_failures_fail_the_render() {
     );
     let _ = std::fs::remove_dir_all(&out);
 }
+
+#[test]
+fn test_style_reference_must_name_a_text_style() {
+    let stderr = generate_scene_expecting_failure(
+        r#"{"scene_format_version":1,"artboard":{"name":"A","width":200,"height":200,"children":[
+           {"type":"node","name":"Decoy","x":10,"y":10},
+           {"type":"text","name":"T","align_value":1,"sizing_value":0,"children":[
+             {"type":"text_style","name":"S","font_size":20},
+             {"type":"text_value_run","name":"R","text":"hi","style":"Decoy"}]}]}}"#,
+        "style_kind",
+    );
+    assert!(
+        stderr.contains("references 'Decoy', which is not a text_style"),
+        "unexpected error: {stderr}"
+    );
+}

--- a/tests/fixtures/game_hud.json
+++ b/tests/fixtures/game_hud.json
@@ -97,14 +97,13 @@
             "name": "ScoreStyle",
             "font_size": 28.0,
             "line_height": 1.2,
-            "letter_spacing": 1.0,
-            "font_asset_id": 1
+            "letter_spacing": 1.0
           },
           {
             "type": "text_value_run",
             "name": "ScoreRun",
             "text": "SCORE: 0",
-            "style_id": 0
+            "style": "ScoreStyle"
           }
         ]
       },
@@ -186,9 +185,18 @@
             "object": "HealthBarRect",
             "property": "width",
             "frames": [
-              { "frame": 0, "value": 196.0 },
-              { "frame": 90, "value": 98.0 },
-              { "frame": 179, "value": 20.0 }
+              {
+                "frame": 0,
+                "value": 196.0
+              },
+              {
+                "frame": 90,
+                "value": 98.0
+              },
+              {
+                "frame": 179,
+                "value": 20.0
+              }
             ]
           }
         ]

--- a/tests/fixtures/keyframe_types.json
+++ b/tests/fixtures/keyframe_types.json
@@ -11,10 +11,26 @@
         "x": 200,
         "y": 200,
         "children": [
-          { "type": "rectangle", "name": "Rect", "width": 100, "height": 100, "origin_x": 0.5, "origin_y": 0.5 },
-          { "type": "fill", "name": "BoxFill", "is_visible": true, "children": [
-            { "type": "solid_color", "name": "Red", "color": "#FF0000" }
-          ]}
+          {
+            "type": "rectangle",
+            "name": "Rect",
+            "width": 100,
+            "height": 100,
+            "origin_x": 0.5,
+            "origin_y": 0.5
+          },
+          {
+            "type": "fill",
+            "name": "BoxFill",
+            "is_visible": true,
+            "children": [
+              {
+                "type": "solid_color",
+                "name": "Red",
+                "color": "#FF0000"
+              }
+            ]
+          }
         ]
       },
       {
@@ -29,14 +45,13 @@
           {
             "type": "text_style",
             "name": "LabelStyle",
-            "font_size": 16.0,
-            "font_asset_id": 1
+            "font_size": 16.0
           },
           {
             "type": "text_value_run",
             "name": "LabelRun",
             "text": "Hello",
-            "style_id": 0
+            "style": "LabelStyle"
           }
         ]
       }
@@ -51,9 +66,18 @@
             "object": "BoxFill",
             "property": "is_visible",
             "frames": [
-              { "frame": 0, "value": true },
-              { "frame": 30, "value": false },
-              { "frame": 59, "value": true }
+              {
+                "frame": 0,
+                "value": true
+              },
+              {
+                "frame": 30,
+                "value": false
+              },
+              {
+                "frame": 59,
+                "value": true
+              }
             ]
           }
         ]
@@ -67,9 +91,18 @@
             "object": "LabelRun",
             "property": "text",
             "frames": [
-              { "frame": 0, "value": "Hello" },
-              { "frame": 30, "value": "World" },
-              { "frame": 59, "value": "Done" }
+              {
+                "frame": 0,
+                "value": "Hello"
+              },
+              {
+                "frame": 30,
+                "value": "World"
+              },
+              {
+                "frame": 59,
+                "value": "Done"
+              }
             ]
           }
         ]


### PR DESCRIPTION
Three pieces of structural debt that each capability in the previous PR added to, removed rather than extended.

## One spec-tree walk

`collect_object_type_key` drives a visitor instead of filling a map, and `SpecIndex::build` runs it **once per artboard** to yield names, type keys, duplicate names and file assets together. `validate_scene_spec` returns those indexes and `build_scene` consumes them, so the tree is walked once for both validation and emission.

Before: `validate_object_spec`, `collect_ambiguous_names`, `collect_object_type_key_named`, `collect_object_type_key`, `validate_image_asset_references`, plus two more per-artboard loops in `build_scene`.

This also fixes a real bug: the ambiguity check reset its seen-set per top-level child, so duplicate names in *separate* subtrees went undetected.

## One reference resolver

`resolve_asset_ordinal`, `resolve_reference`, the inline `style_id` block and `input_index_by_name` collapse into `references::resolve`, parameterised by a `Namespace` (name field, index field, lookup, optional kind check).

Every reference now gets the both-forms-set error and the not-declared error for free, and **the kind check applies identically to the named and numeric forms**. That closed a gap the old design hid: `text_value_run.style` accepted any prior named object, so a run could point at a `node` and generate a broken file. It now requires `TEXT_STYLE_PAINT`:

```
invalid scene spec: 'R' references 'Decoy', which is not a text_style
```

## Harness read from disk in dev

`assets/render-harness.html` stays embedded for release but is read from `CARGO_MANIFEST_DIR` in debug builds, with `RIVE_HARNESS` to override either. Editing the harness no longer needs a rebuild — a stale `include_bytes!` copy is what made a fixed harness look like a live runtime bug during the previous cycle. `AssetServer` now owns its html rather than borrowing `'static`.

Verified: debug picks up an edited harness with no rebuild; release with a bad `RIVE_HARNESS` falls back to the embedded copy and still renders.

## Gates

566 unit + 185 e2e (+6 new), 99 visual baselines at 0 failures, runtime regression clean, demo and site validation at 0 console errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates spec traversal and reference resolution, and reads the render harness from disk in dev. This removes redundant work, tightens validation, and makes harness edits instant.

- **Refactors**
  - Walk the scene spec once per artboard. `SpecIndex::build` gathers names, type keys, ambiguities, and assets; validation uses this index and emission avoids extra passes.
  - Unified reference handling with `references::resolve` and a `Namespace`. Consistent errors for “both forms set” and “not declared,” with kind checks applied to both name and index (assets, inputs, styles).
  - Dev harness now loads from disk in debug or via `RIVE_HARNESS`; release builds embed and gracefully fall back. `AssetServer` now owns the HTML.

- **Bug Fixes**
  - Detect duplicate object names across different subtrees.
  - Enforce that `text_value_run` style resolves to a text style for both named and numeric forms.
  - Reject out-of-range asset indices with a clear error.

<sup>Written for commit 2672ca71dc53e021067adffb3bf05e13a3fbfc1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/George-RD/rive-rs-cli/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

