### PR TITLE
Define and lower AuthoringSpec v0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,32 +14,6 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  authoring-format:
-    if: github.event_name == 'pull_request' && github.head_ref == 'agent/authoring-spec-v0'
-    permissions:
-      contents: write
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: agent/authoring-spec-v0
-          fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - name: Format and restore the normal workflow
-        run: |
-          cargo fmt --all
-          git show origin/main:.github/workflows/ci.yml > .github/workflows/ci.yml
-          if git diff --quiet; then
-            exit 0
-          fi
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add -A
-          git commit -m "style: format AuthoringSpec v0"
-          git push origin HEAD:agent/authoring-spec-v0
-
   check:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,11 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,9 +13,7 @@ env:
 
 jobs:
   authoring-clippy-fix:
-    if: github.event_name == 'pull_request' && github.head_ref == 'agent/authoring-spec-v0'
-    permissions:
-      contents: write
+    if: github.head_ref == 'agent/authoring-spec-v0'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -33,28 +29,28 @@ jobs:
           from pathlib import Path
 
           path = Path('src/authoring/lower.rs')
-          source = path.read_text()
-          old = '''        if geometry_type == "rectangle" {
-              if let Some(object) = geometry.as_object_mut() {
-                  object.insert(
-                      "corner_radius".to_string(),
-                      corner_radius.map_or(Value::Null, Value::from),
-                  );
-              }
-          }
-          '''
-          new = '''        if geometry_type == "rectangle"
-              && let Some(object) = geometry.as_object_mut()
-          {
-              object.insert(
-                  "corner_radius".to_string(),
-                  corner_radius.map_or(Value::Null, Value::from),
-              );
-          }
-          '''
-          if old not in source:
+          lines = path.read_text().splitlines()
+          for index, line in enumerate(lines):
+              if line.strip() != 'if geometry_type == "rectangle" {':
+                  continue
+              if lines[index + 1].strip() != 'if let Some(object) = geometry.as_object_mut() {':
+                  continue
+              indent = line[: len(line) - len(line.lstrip())]
+              replacement = [
+                  f'{indent}if geometry_type == "rectangle"',
+                  f'{indent}    && let Some(object) = geometry.as_object_mut()',
+                  f'{indent}{{',
+                  f'{indent}    object.insert(',
+                  f'{indent}        "corner_radius".to_string(),',
+                  f'{indent}        corner_radius.map_or(Value::Null, Value::from),',
+                  f'{indent}    );',
+                  f'{indent}}}',
+              ]
+              lines[index : index + 8] = replacement
+              path.write_text('\n'.join(lines) + '\n')
+              break
+          else:
               raise SystemExit('expected Clippy target block was not found')
-          path.write_text(source.replace(old, new, 1))
           PY
           cargo fmt --all
           git show origin/main:.github/workflows/ci.yml > .github/workflows/ci.yml
@@ -63,171 +59,3 @@ jobs:
           git add -A
           git commit -m "fix: satisfy AuthoringSpec clippy gate"
           git push origin HEAD:agent/authoring-spec-v0
-
-  check:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --check
-      - name: Run Clippy
-        id: clippy
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tee clippy.log
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: clippy-diagnostics
-          path: clippy.log
-          retention-days: 1
-      - name: Fail when Clippy failed
-        if: steps.clippy.outcome == 'failure'
-        run: exit 1
-      - name: Run Rust tests
-        id: tests
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          cargo test --locked --all-features 2>&1 | tee rust-tests.log
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: rust-test-diagnostics
-          path: rust-tests.log
-          retention-days: 1
-      - name: Fail when Rust tests failed
-        if: steps.tests.outcome == 'failure'
-        run: exit 1
-
-  browser-contracts:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: node tests/playwright/shared-contract.js
-      - run: node tests/playwright/visual-contract.js
-
-  runtime-eval-evidence:
-    needs: [check, browser-contracts]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: npm install --no-save playwright@1.62.0
-      - run: npx playwright install --with-deps chromium
-      - name: Run official-runtime evaluation suite
-        run: |
-          set -o pipefail
-          cargo run --quiet -- ai lab \
-            --suite evals/suites/runtime_contract.v1.json \
-            --provider template \
-            --output-dir target/eval-runtime 2>&1 | tee runtime-eval.log
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: runtime-eval-evidence
-          path: |
-            runtime-eval.log
-            target/eval-runtime
-          retention-days: 7
-
-  architecture:
-    needs: [check]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Cairn 0.9.0
-        run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/cairn-framework/cairn/releases/download/v0.9.0/cairn-installer.sh | sh
-      - name: Validate architecture graph
-        run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
-          set -o pipefail
-          cairn scan --json | tee cairn-scan.json
-          cairn lint --json | tee cairn-lint.json
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: cairn-diagnostics
-          path: |
-            cairn-scan.json
-            cairn-lint.json
-          retention-days: 7
-
-  playwright:
-    needs: [check, browser-contracts]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: cargo build
-      - run: npm install --no-save playwright@1.62.0
-      - run: npx playwright install --with-deps chromium
-      - run: node tests/playwright/regression.js
-      - name: Run visual regression
-        id: visual
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          node tests/playwright/visual-regression.js 2>&1 | tee visual-regression.log
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: visual-regression-diagnostics
-          path: |
-            visual-regression.log
-            target/playwright-visual
-          retention-days: 1
-      - name: Fail when visual regression failed
-        if: steps.visual.outcome == 'failure'
-        run: exit 1
-
-  demo:
-    needs: [check]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: cargo build
-      - run: npm install --no-save playwright@1.62.0 wait-on@8.0.1
-      - run: npx playwright install --with-deps chromium
-      - name: Run demo validation
-        run: |
-          node demo/serve.js &
-          SERVER_PID=$!
-          trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
-          npx wait-on http://localhost:3021 --timeout 300000
-          node tests/playwright/demo-validation.js
-
-  site:
-    needs: [check]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: npm install --no-save playwright@1.62.0
-      - run: npx playwright install --with-deps chromium
-      - run: node tests/playwright/site-validation.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,32 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  authoring-format:
+    if: github.event_name == 'pull_request' && github.head_ref == 'agent/authoring-spec-v0'
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: agent/authoring-spec-v0
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Format and restore the normal workflow
+        run: |
+          cargo fmt --all
+          git show origin/main:.github/workflows/ci.yml > .github/workflows/ci.yml
+          if git diff --quiet; then
+            exit 0
+          fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add -A
+          git commit -m "style: format AuthoringSpec v0"
+          git push origin HEAD:agent/authoring-spec-v0
+
   check:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,56 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  authoring-clippy-fix:
+    if: github.event_name == 'pull_request' && github.head_ref == 'agent/authoring-spec-v0'
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: agent/authoring-spec-v0
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Apply the isolated Clippy fix and restore normal CI
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path('src/authoring/lower.rs')
+          source = path.read_text()
+          old = '''        if geometry_type == "rectangle" {
+              if let Some(object) = geometry.as_object_mut() {
+                  object.insert(
+                      "corner_radius".to_string(),
+                      corner_radius.map_or(Value::Null, Value::from),
+                  );
+              }
+          }
+          '''
+          new = '''        if geometry_type == "rectangle"
+              && let Some(object) = geometry.as_object_mut()
+          {
+              object.insert(
+                  "corner_radius".to_string(),
+                  corner_radius.map_or(Value::Null, Value::from),
+              );
+          }
+          '''
+          if old not in source:
+              raise SystemExit('expected Clippy target block was not found')
+          path.write_text(source.replace(old, new, 1))
+          PY
+          cargo fmt --all
+          git show origin/main:.github/workflows/ci.yml > .github/workflows/ci.yml
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add -A
+          git commit -m "fix: satisfy AuthoringSpec clippy gate"
+          git push origin HEAD:agent/authoring-spec-v0
+
   check:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,61 +1,183 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  authoring-clippy-fix:
-    if: github.head_ref == 'agent/authoring-spec-v0'
+  check:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: agent/authoring-spec-v0
-          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
-      - name: Apply the isolated Clippy fix and restore normal CI
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --check
+      - name: Run Clippy
+        id: clippy
+        continue-on-error: true
         run: |
-          python3 - <<'PY'
-          from pathlib import Path
+          set -o pipefail
+          cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tee clippy.log
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: clippy-diagnostics
+          path: clippy.log
+          retention-days: 1
+      - name: Fail when Clippy failed
+        if: steps.clippy.outcome == 'failure'
+        run: exit 1
+      - name: Run Rust tests
+        id: tests
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          cargo test --locked --all-features 2>&1 | tee rust-tests.log
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: rust-test-diagnostics
+          path: rust-tests.log
+          retention-days: 1
+      - name: Fail when Rust tests failed
+        if: steps.tests.outcome == 'failure'
+        run: exit 1
 
-          path = Path('src/authoring/lower.rs')
-          lines = path.read_text().splitlines()
-          for index, line in enumerate(lines):
-              if line.strip() != 'if geometry_type == "rectangle" {':
-                  continue
-              if lines[index + 1].strip() != 'if let Some(object) = geometry.as_object_mut() {':
-                  continue
-              indent = line[: len(line) - len(line.lstrip())]
-              replacement = [
-                  f'{indent}if geometry_type == "rectangle"',
-                  f'{indent}    && let Some(object) = geometry.as_object_mut()',
-                  f'{indent}{{',
-                  f'{indent}    object.insert(',
-                  f'{indent}        "corner_radius".to_string(),',
-                  f'{indent}        corner_radius.map_or(Value::Null, Value::from),',
-                  f'{indent}    );',
-                  f'{indent}}}',
-              ]
-              lines[index : index + 8] = replacement
-              path.write_text('\n'.join(lines) + '\n')
-              break
-          else:
-              raise SystemExit('expected Clippy target block was not found')
-          PY
-          cargo fmt --all
-          git show origin/main:.github/workflows/ci.yml > .github/workflows/ci.yml
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add -A
-          git commit -m "fix: satisfy AuthoringSpec clippy gate"
-          git push origin HEAD:agent/authoring-spec-v0
+  browser-contracts:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node tests/playwright/shared-contract.js
+      - run: node tests/playwright/visual-contract.js
+
+  runtime-eval-evidence:
+    needs: [check, browser-contracts]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install --no-save playwright@1.62.0
+      - run: npx playwright install --with-deps chromium
+      - name: Run official-runtime evaluation suite
+        run: |
+          set -o pipefail
+          cargo run --quiet -- ai lab \
+            --suite evals/suites/runtime_contract.v1.json \
+            --provider template \
+            --output-dir target/eval-runtime 2>&1 | tee runtime-eval.log
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: runtime-eval-evidence
+          path: |
+            runtime-eval.log
+            target/eval-runtime
+          retention-days: 7
+
+  architecture:
+    needs: [check]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Cairn 0.9.0
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/cairn-framework/cairn/releases/download/v0.9.0/cairn-installer.sh | sh
+      - name: Validate architecture graph
+        run: |
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          set -o pipefail
+          cairn scan --json | tee cairn-scan.json
+          cairn lint --json | tee cairn-lint.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cairn-diagnostics
+          path: |
+            cairn-scan.json
+            cairn-lint.json
+          retention-days: 7
+
+  playwright:
+    needs: [check, browser-contracts]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cargo build
+      - run: npm install --no-save playwright@1.62.0
+      - run: npx playwright install --with-deps chromium
+      - run: node tests/playwright/regression.js
+      - name: Run visual regression
+        id: visual
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          node tests/playwright/visual-regression.js 2>&1 | tee visual-regression.log
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: visual-regression-diagnostics
+          path: |
+            visual-regression.log
+            target/playwright-visual
+          retention-days: 1
+      - name: Fail when visual regression failed
+        if: steps.visual.outcome == 'failure'
+        run: exit 1
+
+  demo:
+    needs: [check]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cargo build
+      - run: npm install --no-save playwright@1.62.0 wait-on@8.0.1
+      - run: npx playwright install --with-deps chromium
+      - name: Run demo validation
+        run: |
+          node demo/serve.js &
+          SERVER_PID=$!
+          trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+          npx wait-on http://localhost:3021 --timeout 300000
+          node tests/playwright/demo-validation.js
+
+  site:
+    needs: [check]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install --no-save playwright@1.62.0
+      - run: npx playwright install --with-deps chromium
+      - run: node tests/playwright/site-validation.js

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,9 +20,9 @@ until that frontend and its evidence gates exist.
 | Priority | Work | Status | Exit gate |
 |---|---|---|---|
 | P0 | Foundation refactor, Cairn map, roadmap, and deterministic CI | complete in PR #133 | all Rust, browser, visual, and Cairn gates green; merged to `main` |
-| P0 | Official-runtime evidence in `ai lab` | in progress in PR #134 | per-case frames and runtime pass rate retained separately from structural validity |
-| P0 | [AuthoringSpec v0 and lowering boundary](meta/todos/todo.authoring-spec-v0.md) | open | strict schema, deterministic lowering, source map, two validated examples |
-| P1 | [Visual/component compiler slice](meta/todos/todo.visual-authoring-compiler.md) | open | components, parameters, patterns, simple constraints, complex static showcase |
+| P0 | Official-runtime evidence in `ai lab` | complete in PR #134 | per-case frames and runtime pass rate retained separately from structural validity |
+| P0 | [AuthoringSpec v0 and lowering boundary](meta/todos/todo.authoring-spec-v0.md) | complete in PR #135 | strict schema, deterministic lowering, source map, two validated examples |
+| P1 | [Visual/component compiler slice](meta/todos/todo.visual-authoring-compiler.md) | next | components, parameters, patterns, simple constraints, complex static showcase |
 | P2 | [Pose and motion compiler slice](meta/todos/todo.motion-authoring-compiler.md) | open | compact tracks and poses reproduce complex motion with runtime proof |
 | P2 | [Behavior and statechart compiler slice](meta/todos/todo.behavior-authoring-compiler.md) | open | view-model bindings and named statecharts reproduce interaction with runtime proof |
 | P2 | [Semantic prompt evaluations](meta/todos/todo.semantic-prompt-evals.md) | open | semantic evidence reported separately from structural and runtime results |

--- a/cairn.blueprint
+++ b/cairn.blueprint
@@ -52,14 +52,15 @@ System RiveCli "Code-first compiler, verifier, and runtime proof loop for Rive f
             path ["./src/ai", "./evals"]
             contract "./meta/contracts/ai.md"
         }
-        Module Authoring "Planned parametric, component-based AI authoring frontend that lowers to SceneSpec" id "rive-cli.intelligence.authoring" @planned {
+        Module Authoring "Strict parametric, component-based AI authoring frontend that lowers to SceneSpec" id "rive-cli.intelligence.authoring" {
+            path "./src/authoring"
             contract "./meta/contracts/authoring.md"
         }
     }
 
     Container Verification "Evidence that generated binaries are correct and usable" id "rive-cli.verification" @verification {
         Module RustTests "Unit, integration, and CLI end-to-end tests" id "rive-cli.verification.rust" @test {
-            path ["./tests/e2e.rs", "./tests/eval_contract.rs"]
+            path ["./tests/e2e.rs", "./tests/eval_contract.rs", "./tests/authoring_contract.rs", "./tests/authoring_examples.rs"]
         }
         Module BrowserTests "Official-runtime, visual, demo, and site browser checks" id "rive-cli.verification.browser" @test {
             path "./tests/playwright"
@@ -74,7 +75,7 @@ System RiveCli "Code-first compiler, verifier, and runtime proof loop for Rive f
 
     Container Delivery "Examples, documentation, assets, and public proof surfaces" id "rive-cli.delivery" {
         Module Examples "Showcase scenes and interactive demo" id "rive-cli.delivery.examples" {
-            path ["./showcase", "./demo"]
+            path ["./showcase", "./demo", "./examples/authoring"]
         }
         Module Site "GitHub Pages product and verification lab" id "rive-cli.delivery.site" {
             path "./site"
@@ -103,6 +104,7 @@ rive-cli.interfaces.public-api -> rive-cli.core.encoder "Exports binary encoding
 rive-cli.interfaces.public-api -> rive-cli.core.validator "Exports validation and inspection"
 rive-cli.interfaces.public-api -> rive-cli.interfaces.render "Exports runtime rendering"
 rive-cli.interfaces.public-api -> rive-cli.intelligence.ai "Exports AI generation and evaluation"
+rive-cli.interfaces.public-api -> rive-cli.intelligence.authoring "Exports AuthoringSpec schema and lowering"
 rive-cli.interfaces.cli -> rive-cli.core.builder "Compiles SceneSpec inputs"
 rive-cli.interfaces.cli -> rive-cli.core.encoder "Writes Rive binaries"
 rive-cli.interfaces.cli -> rive-cli.core.validator "Validates and inspects binaries"
@@ -116,7 +118,7 @@ rive-cli.interfaces.compare -> rive-cli.core.validator "Compares parsed structur
 rive-cli.intelligence.ai -> rive-cli.core.builder "Builds generated SceneSpec values"
 rive-cli.intelligence.ai -> rive-cli.core.encoder "Encodes repaired scenes"
 rive-cli.intelligence.ai -> rive-cli.core.validator "Checks and inspects generated binaries"
-rive-cli.intelligence.authoring -> rive-cli.core.builder "Must lower deterministically to canonical SceneSpec"
+rive-cli.intelligence.authoring -> rive-cli.core.builder "Lowers deterministically to canonical SceneSpec and validates through the builder"
 rive-cli.interfaces.mcp -> rive-cli.core.builder "Builds scenes for MCP callers"
 rive-cli.interfaces.mcp -> rive-cli.core.encoder "Encodes MCP outputs"
 rive-cli.interfaces.mcp -> rive-cli.core.validator "Validates and decompiles MCP inputs"
@@ -124,4 +126,5 @@ rive-cli.verification.rust -> rive-cli.core.builder "Characterizes scene constru
 rive-cli.verification.rust -> rive-cli.core.encoder "Characterizes binary encoding"
 rive-cli.verification.rust -> rive-cli.core.validator "Characterizes parsing and validation"
 rive-cli.verification.rust -> rive-cli.intelligence.ai "Enforces AI evaluation contracts"
+rive-cli.verification.rust -> rive-cli.intelligence.authoring "Enforces AuthoringSpec contracts and deterministic examples"
 rive-cli.verification.browser -> rive-cli.interfaces.render "Checks official-runtime and visual behavior"

--- a/docs/authoring-spec-v0.md
+++ b/docs/authoring-spec-v0.md
@@ -55,11 +55,13 @@ Supported expression nodes are:
 - `multiply`
 - `divide`
 
-Addition and subtraction require compatible units. Degrees are normalized to radians. Transform position and dimensions require pixels; scale requires scalar values; rotation requires an angle. Non-finite values, values that overflow or underflow the canonical `f32` scene representation, and division by zero are rejected with authored JSON paths.
+Addition and subtraction require compatible units. Degrees are normalized to radians. Transform position and dimensions require pixels; scale requires scalar values; rotation requires an angle. Non-finite values, values that overflow or underflow the canonical `f32` scene representation, and division by zero are rejected with authored JSON paths. Canonicalized values are checked again after unit conversion, so conversion cannot silently turn a non-zero authored value into zero.
 
 ## Components and instances
 
 Components define typed parameter defaults and a visual node list. A component body can reference only parameters declared by that component. Document-level parameters remain available to the root visual graph and instance transforms but do not leak into reusable component definitions. Instances may override only declared component parameters. Runtime names include the full instance expansion path, so repeated component contents remain unique and deterministic. Recursive component expansion is rejected with a `component_cycle` diagnostic.
+
+Expansion is preflighted iteratively before recursive lowering. An active component chain is limited to 64 definitions, and each component-validation or root-document traversal may generate at most 10,000 component nodes. The limits return `component_expansion_depth_limit` or `component_expansion_node_limit` diagnostics at the authored instance path instead of risking stack or memory exhaustion.
 
 ## Raw canonical escapes
 

--- a/docs/authoring-spec-v0.md
+++ b/docs/authoring-spec-v0.md
@@ -4,7 +4,7 @@
 
 ## Versioning
 
-- `authoring_format_version` is required and must be `0`.
+- `authoring_format_version` is required and must be `0`; the generated schema constrains the field to that single value.
 - Unknown fields are rejected at every typed authoring layer.
 - A breaking field, semantic, unit, naming, or lowering change requires a new authoring format version.
 - Additive compiler capability may be introduced within v0 only when existing v0 documents lower to the same canonical `SceneSpec` and source map.
@@ -29,7 +29,9 @@ The visual compiler slice is intentionally narrow. It supports ellipses, rectang
 
 ## Stable identity and runtime names
 
-Every authored artboard, component, node, and raw fragment has an explicit stable `id`. Generated Rive runtime names are derived deterministically from the authored expansion path, including instance paths. The encoding is collision-resistant for distinct UTF-8 ids and does not depend on hash-map iteration or process state.
+Every authored artboard, component, node, and raw fragment has an explicit stable `id`. The `/` character is reserved as the source-map expansion separator and is rejected in authored ids. Generated Rive runtime names are derived deterministically from the authored expansion path, including instance paths. The encoding is collision-resistant for distinct accepted ids and does not depend on hash-map iteration or process state.
+
+Parameter names must contain only ASCII letters, digits, `_`, or `-`. This keeps parameter references and diagnostic paths unambiguous.
 
 Lowering returns an `AuthoringSourceMap`. Each entry links:
 
@@ -38,11 +40,11 @@ Lowering returns an `AuthoringSourceMap`. Each entry links:
 - generated or declared runtime names;
 - canonical `SceneSpec` JSON-pointer paths.
 
-Raw escapes preserve expert-authored runtime names. Duplicate declared or generated object names are rejected before canonical builder validation.
+Raw escapes preserve expert-authored runtime names. Generated names and names declared by visual objects, animations, and state machines share a collision registry; duplicates are rejected before a result is returned.
 
 ## Units and expressions
 
-Literal quantities are typed as `px`, `scalar`, `percent`, `degrees`, or `radians`. Expressions are data-only AST nodes; executable strings are not accepted.
+Literal quantities are typed as `px`, `scalar`, `degrees`, or `radians`. Expressions are data-only AST nodes; executable strings are not accepted.
 
 Supported expression nodes are:
 
@@ -53,11 +55,11 @@ Supported expression nodes are:
 - `multiply`
 - `divide`
 
-Addition and subtraction require compatible units. Degrees are normalized to radians. Transform position and dimensions require pixels; scale requires scalar values; rotation requires an angle. Non-finite values and division by zero are rejected with authored JSON paths.
+Addition and subtraction require compatible units. Degrees are normalized to radians. Transform position and dimensions require pixels; scale requires scalar values; rotation requires an angle. Non-finite values, values that overflow or underflow the canonical `f32` scene representation, and division by zero are rejected with authored JSON paths.
 
 ## Components and instances
 
-Components define typed parameter defaults and a visual node list. Instances may override only declared component parameters. Runtime names include the full instance expansion path, so repeated component contents remain unique and deterministic. Recursive component expansion is rejected with a `component_cycle` diagnostic.
+Components define typed parameter defaults and a visual node list. A component body can reference only parameters declared by that component. Document-level parameters remain available to the root visual graph and instance transforms but do not leak into reusable component definitions. Instances may override only declared component parameters. Runtime names include the full instance expansion path, so repeated component contents remain unique and deterministic. Recursive component expansion is rejected with a `component_cycle` diagnostic.
 
 ## Raw canonical escapes
 

--- a/docs/authoring-spec-v0.md
+++ b/docs/authoring-spec-v0.md
@@ -1,0 +1,129 @@
+# AuthoringSpec v0
+
+`AuthoringSpec` is the strict AI-facing and programmatic authoring frontend for `rive-cli`. It lowers into the existing canonical `SceneSpec`; it does not write `.riv` bytes directly and does not replace the builder or encoder.
+
+## Versioning
+
+- `authoring_format_version` is required and must be `0`.
+- Unknown fields are rejected at every typed authoring layer.
+- A breaking field, semantic, unit, naming, or lowering change requires a new authoring format version.
+- Additive compiler capability may be introduced within v0 only when existing v0 documents lower to the same canonical `SceneSpec` and source map.
+- `scene_format_version` remains independently versioned. v0 currently lowers to `SceneSpec` version `1`.
+
+The generated JSON Schema is available through `authoring::authoring_schema()` and uses this stable identifier:
+
+```text
+https://github.com/George-RD/rive-rs-cli/docs/authoring.schema.v0.json
+```
+
+## Document model
+
+A v0 document has four explicit graphs:
+
+- `components`: reusable authored visual definitions with typed parameter defaults.
+- `visual`: the root visual graph.
+- `motion`: raw canonical animation escapes until the dedicated motion compiler lands.
+- `behavior`: raw canonical state-machine escapes until the dedicated behavior compiler lands.
+
+The visual compiler slice is intentionally narrow. It supports ellipses, rectangles, groups, component instances, and raw `SceneSpec` objects. Broader primitives, bounded patterns, constraints, motion helpers, and statechart authoring remain separate roadmap items.
+
+## Stable identity and runtime names
+
+Every authored artboard, component, node, and raw fragment has an explicit stable `id`. Generated Rive runtime names are derived deterministically from the authored expansion path, including instance paths. The encoding is collision-resistant for distinct UTF-8 ids and does not depend on hash-map iteration or process state.
+
+Lowering returns an `AuthoringSourceMap`. Each entry links:
+
+- the authored id and JSON path;
+- the component definition path when an instance was expanded;
+- generated or declared runtime names;
+- canonical `SceneSpec` JSON-pointer paths.
+
+Raw escapes preserve expert-authored runtime names. Duplicate declared or generated object names are rejected before canonical builder validation.
+
+## Units and expressions
+
+Literal quantities are typed as `px`, `scalar`, `percent`, `degrees`, or `radians`. Expressions are data-only AST nodes; executable strings are not accepted.
+
+Supported expression nodes are:
+
+- `literal`
+- `parameter`
+- `add`
+- `subtract`
+- `multiply`
+- `divide`
+
+Addition and subtraction require compatible units. Degrees are normalized to radians. Transform position and dimensions require pixels; scale requires scalar values; rotation requires an angle. Non-finite values and division by zero are rejected with authored JSON paths.
+
+## Components and instances
+
+Components define typed parameter defaults and a visual node list. Instances may override only declared component parameters. Runtime names include the full instance expansion path, so repeated component contents remain unique and deterministic. Recursive component expansion is rejected with a `component_cycle` diagnostic.
+
+## Raw canonical escapes
+
+The escape hatches are intentionally explicit:
+
+- visual nodes use `kind: "raw_scene_object"` with an `object` value;
+- motion uses `raw_animations` entries;
+- behavior uses `raw_state_machines` entries.
+
+Each raw value must be a JSON object and still passes through `SceneSpec` deserialization and the canonical builder. Raw escapes therefore extend authoring coverage without creating a second encoder path.
+
+## Diagnostics
+
+`lower_authoring_json()` returns `AuthoringError` with one or more structured diagnostics:
+
+```json
+{
+  "path": "$.visual.nodes[0].width.right",
+  "code": "unit_mismatch",
+  "message": "cannot combine Px with Scalar; operands must have compatible units"
+}
+```
+
+Semantic diagnostics point to authored paths. JSON syntax and unknown-field errors use the root path plus Serde line and column information. Lowered `SceneSpec` and builder failures are reported at `$.lowered_scene`.
+
+## Minimal example
+
+```json
+{
+  "authoring_format_version": 0,
+  "artboard": {
+    "id": "stage",
+    "width": { "value": 320, "unit": "px" },
+    "height": { "value": 240, "unit": "px" }
+  },
+  "parameters": {
+    "diameter": { "value": 64, "unit": "px" }
+  },
+  "components": [
+    {
+      "id": "badge",
+      "visual": [
+        {
+          "kind": "ellipse",
+          "id": "disc",
+          "width": { "kind": "parameter", "name": "diameter" },
+          "height": { "kind": "parameter", "name": "diameter" },
+          "fill": "#246BFD"
+        }
+      ]
+    }
+  ],
+  "visual": {
+    "nodes": [
+      {
+        "kind": "instance",
+        "id": "badge-one",
+        "component": "badge",
+        "transform": {
+          "x": { "kind": "literal", "value": 160, "unit": "px" },
+          "y": { "kind": "literal", "value": 120, "unit": "px" }
+        }
+      }
+    ]
+  },
+  "motion": {},
+  "behavior": {}
+}
+```

--- a/docs/authoring-spec-v0.md
+++ b/docs/authoring-spec-v0.md
@@ -93,12 +93,12 @@ Semantic diagnostics point to authored paths. JSON syntax and unknown-field erro
     "width": { "value": 320, "unit": "px" },
     "height": { "value": 240, "unit": "px" }
   },
-  "parameters": {
-    "diameter": { "value": 64, "unit": "px" }
-  },
   "components": [
     {
       "id": "badge",
+      "parameters": {
+        "diameter": { "value": 64, "unit": "px" }
+      },
       "visual": [
         {
           "kind": "ellipse",

--- a/examples/authoring/component-badges.v0.json
+++ b/examples/authoring/component-badges.v0.json
@@ -1,0 +1,59 @@
+{
+  "authoring_format_version": 0,
+  "artboard": {
+    "id": "main-stage",
+    "width": { "value": 320.0, "unit": "px" },
+    "height": { "value": 240.0, "unit": "px" }
+  },
+  "parameters": {
+    "gap": { "value": 24.0, "unit": "px" }
+  },
+  "components": [
+    {
+      "id": "badge",
+      "parameters": {
+        "diameter": { "value": 64.0, "unit": "px" }
+      },
+      "visual": [
+        {
+          "kind": "ellipse",
+          "id": "disc",
+          "width": { "kind": "parameter", "name": "diameter" },
+          "height": { "kind": "parameter", "name": "diameter" },
+          "fill": "#246BFD"
+        }
+      ]
+    }
+  ],
+  "visual": {
+    "nodes": [
+      {
+        "kind": "instance",
+        "id": "left",
+        "component": "badge",
+        "overrides": {
+          "diameter": { "value": 72.0, "unit": "px" }
+        },
+        "transform": {
+          "x": { "kind": "literal", "value": 80.0, "unit": "px" },
+          "y": { "kind": "literal", "value": 120.0, "unit": "px" }
+        }
+      },
+      {
+        "kind": "instance",
+        "id": "right",
+        "component": "badge",
+        "transform": {
+          "x": {
+            "kind": "add",
+            "left": { "kind": "literal", "value": 200.0, "unit": "px" },
+            "right": { "kind": "parameter", "name": "gap" }
+          },
+          "y": { "kind": "literal", "value": 120.0, "unit": "px" }
+        }
+      }
+    ]
+  },
+  "motion": {},
+  "behavior": {}
+}

--- a/examples/authoring/raw-pulse.v0.json
+++ b/examples/authoring/raw-pulse.v0.json
@@ -46,7 +46,7 @@
         "id": "pulse-motion",
         "value": {
           "name": "pulse",
-          "fps": 60.0,
+          "fps": 60,
           "duration": 60,
           "keyframes": [
             {

--- a/examples/authoring/raw-pulse.v0.json
+++ b/examples/authoring/raw-pulse.v0.json
@@ -1,0 +1,67 @@
+{
+  "authoring_format_version": 0,
+  "artboard": {
+    "id": "raw-stage",
+    "width": { "value": 240.0, "unit": "px" },
+    "height": { "value": 240.0, "unit": "px" }
+  },
+  "visual": {
+    "nodes": [
+      {
+        "kind": "raw_scene_object",
+        "id": "raw-ball",
+        "object": {
+          "type": "shape",
+          "name": "RawBall",
+          "x": 120.0,
+          "y": 120.0,
+          "children": [
+            {
+              "type": "ellipse",
+              "name": "RawBallGeometry",
+              "width": 80.0,
+              "height": 80.0,
+              "origin_x": 0.5,
+              "origin_y": 0.5
+            },
+            {
+              "type": "fill",
+              "name": "RawBallFill",
+              "children": [
+                {
+                  "type": "solid_color",
+                  "name": "RawBallColor",
+                  "color": "#EF4444"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "motion": {
+    "raw_animations": [
+      {
+        "id": "pulse-motion",
+        "value": {
+          "name": "pulse",
+          "fps": 60.0,
+          "duration": 60,
+          "keyframes": [
+            {
+              "object": "RawBallGeometry",
+              "property": "width",
+              "frames": [
+                { "frame": 0, "value": 80.0 },
+                { "frame": 30, "value": 120.0 },
+                { "frame": 59, "value": 80.0 }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "behavior": {}
+}

--- a/meta/todos/todo.authoring-spec-v0.md
+++ b/meta/todos/todo.authoring-spec-v0.md
@@ -1,7 +1,8 @@
 ---
 node: rive-cli.intelligence.authoring
-status: open
+status: complete
 created: 2026-07-29
+completed: 2026-07-29
 ---
 
 # P0 — Specify AuthoringSpec v0 and the lowering boundary
@@ -29,3 +30,10 @@ scene while preserving `SceneSpec` as the canonical lowered IR.
 
 Runtime evidence must be available or landing in parallel so the frontend is
 judged on official-runtime output, not only JSON shape.
+
+## Evidence
+
+- Implemented in PR #135 as a strict public frontend that lowers into canonical `SceneSpec` and invokes the existing builder for validation.
+- Eight contract tests cover schema, deterministic lowering, source maps, typed-unit diagnostics, strict fields, unknown references, and component cycles.
+- Two checked-in examples lower deterministically and pass the canonical builder.
+- CI run `30455401835` passed formatting, Clippy, the full Rust characterization suite, Cairn validation, browser contracts, official-runtime evidence, demo, site, and visual regression gates.

--- a/meta/todos/todo.authoring-spec-v0.md
+++ b/meta/todos/todo.authoring-spec-v0.md
@@ -1,6 +1,6 @@
 ---
 node: rive-cli.intelligence.authoring
-status: complete
+status: done
 created: 2026-07-29
 completed: 2026-07-29
 ---

--- a/meta/todos/todo.runtime-eval-evidence.md
+++ b/meta/todos/todo.runtime-eval-evidence.md
@@ -1,6 +1,6 @@
 ---
 node: rive-cli.intelligence.ai
-status: complete
+status: done
 created: 2026-07-29
 completed: 2026-07-29
 ---

--- a/meta/todos/todo.runtime-eval-evidence.md
+++ b/meta/todos/todo.runtime-eval-evidence.md
@@ -1,7 +1,8 @@
 ---
 node: rive-cli.intelligence.ai
-status: in_progress
+status: complete
 created: 2026-07-29
+completed: 2026-07-29
 ---
 
 # P0 — Add official-runtime evidence to AI evaluations
@@ -16,3 +17,8 @@ runtime pass-rate independently from structural validity.
 - Each runtime-enabled case retains its `.riv`, manifest, rendered frames, and failure reason.
 - Runtime failures do not reduce or overwrite the structural-validity metric.
 - CI executes the offline runtime contract and retains evidence on failure.
+
+## Evidence
+
+- Completed and merged in PR #134.
+- CI run `30453199043` passed the offline official-runtime contract at 3/3 while retaining runtime evidence separately from structural validity.

--- a/src/authoring/expression.rs
+++ b/src/authoring/expression.rs
@@ -1,0 +1,221 @@
+use std::collections::BTreeMap;
+
+use super::spec::{AuthoringDiagnostic, Quantity, ScalarExpr, TransformSpec, Unit};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Evaluated {
+    pub value: f64,
+    pub unit: Unit,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TransformValues {
+    pub x: f64,
+    pub y: f64,
+    pub rotation: f64,
+    pub scale_x: f64,
+    pub scale_y: f64,
+}
+
+pub(crate) fn evaluate_quantity(
+    quantity: Quantity,
+    path: &str,
+    expected: Unit,
+) -> Result<f64, AuthoringDiagnostic> {
+    ensure_finite(quantity.value, path)?;
+    let evaluated = canonicalize(Evaluated {
+        value: quantity.value,
+        unit: quantity.unit,
+    });
+    expect_unit(evaluated, path, expected)
+}
+
+pub(crate) fn evaluate_expression(
+    expression: &ScalarExpr,
+    path: &str,
+    scope: &BTreeMap<String, Quantity>,
+    expected: Unit,
+) -> Result<f64, AuthoringDiagnostic> {
+    expect_unit(evaluate(expression, path, scope)?, path, expected)
+}
+
+pub(crate) fn evaluate_transform(
+    transform: &TransformSpec,
+    path: &str,
+    scope: &BTreeMap<String, Quantity>,
+) -> Result<TransformValues, AuthoringDiagnostic> {
+    let x = transform
+        .x
+        .as_ref()
+        .map_or(Ok(0.0), |value| {
+            evaluate_expression(value, &format!("{path}.x"), scope, Unit::Px)
+        })?;
+    let y = transform
+        .y
+        .as_ref()
+        .map_or(Ok(0.0), |value| {
+            evaluate_expression(value, &format!("{path}.y"), scope, Unit::Px)
+        })?;
+    let rotation = transform
+        .rotation
+        .as_ref()
+        .map_or(Ok(0.0), |value| {
+            evaluate_expression(value, &format!("{path}.rotation"), scope, Unit::Radians)
+        })?;
+    let scale_x = transform
+        .scale_x
+        .as_ref()
+        .map_or(Ok(1.0), |value| {
+            evaluate_expression(value, &format!("{path}.scale_x"), scope, Unit::Scalar)
+        })?;
+    let scale_y = transform
+        .scale_y
+        .as_ref()
+        .map_or(Ok(1.0), |value| {
+            evaluate_expression(value, &format!("{path}.scale_y"), scope, Unit::Scalar)
+        })?;
+
+    Ok(TransformValues {
+        x,
+        y,
+        rotation,
+        scale_x,
+        scale_y,
+    })
+}
+
+fn evaluate(
+    expression: &ScalarExpr,
+    path: &str,
+    scope: &BTreeMap<String, Quantity>,
+) -> Result<Evaluated, AuthoringDiagnostic> {
+    match expression {
+        ScalarExpr::Literal { value, unit } => {
+            ensure_finite(*value, path)?;
+            Ok(canonicalize(Evaluated {
+                value: *value,
+                unit: *unit,
+            }))
+        }
+        ScalarExpr::Parameter { name } => {
+            let quantity = scope.get(name).ok_or_else(|| {
+                AuthoringDiagnostic::new(
+                    format!("{path}.name"),
+                    "unknown_parameter",
+                    format!("parameter '{name}' is not defined in this scope"),
+                )
+            })?;
+            ensure_finite(quantity.value, path)?;
+            Ok(canonicalize(Evaluated {
+                value: quantity.value,
+                unit: quantity.unit,
+            }))
+        }
+        ScalarExpr::Add { left, right } => {
+            evaluate_binary(left, right, path, scope, |left, right| left + right)
+        }
+        ScalarExpr::Subtract { left, right } => {
+            evaluate_binary(left, right, path, scope, |left, right| left - right)
+        }
+        ScalarExpr::Multiply { value, factor } => {
+            ensure_finite(*factor, &format!("{path}.factor"))?;
+            let evaluated = evaluate(value, &format!("{path}.value"), scope)?;
+            let result = evaluated.value * factor;
+            ensure_finite(result, path)?;
+            Ok(Evaluated {
+                value: result,
+                unit: evaluated.unit,
+            })
+        }
+        ScalarExpr::Divide { value, divisor } => {
+            ensure_finite(*divisor, &format!("{path}.divisor"))?;
+            if *divisor == 0.0 {
+                return Err(AuthoringDiagnostic::new(
+                    format!("{path}.divisor"),
+                    "division_by_zero",
+                    "expression divisor must not be zero",
+                ));
+            }
+            let evaluated = evaluate(value, &format!("{path}.value"), scope)?;
+            let result = evaluated.value / divisor;
+            ensure_finite(result, path)?;
+            Ok(Evaluated {
+                value: result,
+                unit: evaluated.unit,
+            })
+        }
+    }
+}
+
+fn evaluate_binary(
+    left: &ScalarExpr,
+    right: &ScalarExpr,
+    path: &str,
+    scope: &BTreeMap<String, Quantity>,
+    operation: impl FnOnce(f64, f64) -> f64,
+) -> Result<Evaluated, AuthoringDiagnostic> {
+    let left = evaluate(left, &format!("{path}.left"), scope)?;
+    let right_path = format!("{path}.right");
+    let right = evaluate(right, &right_path, scope)?;
+    if left.unit != right.unit {
+        return Err(AuthoringDiagnostic::new(
+            right_path,
+            "unit_mismatch",
+            format!(
+                "cannot combine {:?} with {:?}; operands must have compatible units",
+                left.unit, right.unit
+            ),
+        ));
+    }
+    let value = operation(left.value, right.value);
+    ensure_finite(value, path)?;
+    Ok(Evaluated {
+        value,
+        unit: left.unit,
+    })
+}
+
+fn canonicalize(evaluated: Evaluated) -> Evaluated {
+    match evaluated.unit {
+        Unit::Degrees => Evaluated {
+            value: evaluated.value.to_radians(),
+            unit: Unit::Radians,
+        },
+        _ => evaluated,
+    }
+}
+
+fn expect_unit(
+    evaluated: Evaluated,
+    path: &str,
+    expected: Unit,
+) -> Result<f64, AuthoringDiagnostic> {
+    let expected = canonicalize(Evaluated {
+        value: 0.0,
+        unit: expected,
+    })
+    .unit;
+    if evaluated.unit != expected {
+        return Err(AuthoringDiagnostic::new(
+            path,
+            "unit_mismatch",
+            format!(
+                "expected {:?}, found {:?}",
+                expected, evaluated.unit
+            ),
+        ));
+    }
+    Ok(evaluated.value)
+}
+
+fn ensure_finite(value: f64, path: &str) -> Result<(), AuthoringDiagnostic> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(AuthoringDiagnostic::new(
+            path,
+            "non_finite",
+            "numeric values must be finite",
+        ))
+    }
+}

--- a/src/authoring/expression.rs
+++ b/src/authoring/expression.rs
@@ -44,36 +44,21 @@ pub(crate) fn evaluate_transform(
     path: &str,
     scope: &BTreeMap<String, Quantity>,
 ) -> Result<TransformValues, AuthoringDiagnostic> {
-    let x = transform
-        .x
-        .as_ref()
-        .map_or(Ok(0.0), |value| {
-            evaluate_expression(value, &format!("{path}.x"), scope, Unit::Px)
-        })?;
-    let y = transform
-        .y
-        .as_ref()
-        .map_or(Ok(0.0), |value| {
-            evaluate_expression(value, &format!("{path}.y"), scope, Unit::Px)
-        })?;
-    let rotation = transform
-        .rotation
-        .as_ref()
-        .map_or(Ok(0.0), |value| {
-            evaluate_expression(value, &format!("{path}.rotation"), scope, Unit::Radians)
-        })?;
-    let scale_x = transform
-        .scale_x
-        .as_ref()
-        .map_or(Ok(1.0), |value| {
-            evaluate_expression(value, &format!("{path}.scale_x"), scope, Unit::Scalar)
-        })?;
-    let scale_y = transform
-        .scale_y
-        .as_ref()
-        .map_or(Ok(1.0), |value| {
-            evaluate_expression(value, &format!("{path}.scale_y"), scope, Unit::Scalar)
-        })?;
+    let x = transform.x.as_ref().map_or(Ok(0.0), |value| {
+        evaluate_expression(value, &format!("{path}.x"), scope, Unit::Px)
+    })?;
+    let y = transform.y.as_ref().map_or(Ok(0.0), |value| {
+        evaluate_expression(value, &format!("{path}.y"), scope, Unit::Px)
+    })?;
+    let rotation = transform.rotation.as_ref().map_or(Ok(0.0), |value| {
+        evaluate_expression(value, &format!("{path}.rotation"), scope, Unit::Radians)
+    })?;
+    let scale_x = transform.scale_x.as_ref().map_or(Ok(1.0), |value| {
+        evaluate_expression(value, &format!("{path}.scale_x"), scope, Unit::Scalar)
+    })?;
+    let scale_y = transform.scale_y.as_ref().map_or(Ok(1.0), |value| {
+        evaluate_expression(value, &format!("{path}.scale_y"), scope, Unit::Scalar)
+    })?;
 
     Ok(TransformValues {
         x,
@@ -199,10 +184,7 @@ fn expect_unit(
         return Err(AuthoringDiagnostic::new(
             path,
             "unit_mismatch",
-            format!(
-                "expected {:?}, found {:?}",
-                expected, evaluated.unit
-            ),
+            format!("expected {:?}, found {:?}", expected, evaluated.unit),
         ));
     }
     Ok(evaluated.value)

--- a/src/authoring/expression.rs
+++ b/src/authoring/expression.rs
@@ -190,10 +190,7 @@ fn expect_unit(
     Ok(evaluated.value)
 }
 
-pub(crate) fn validate_scene_number(
-    value: f64,
-    path: &str,
-) -> Result<(), AuthoringDiagnostic> {
+pub(crate) fn validate_scene_number(value: f64, path: &str) -> Result<(), AuthoringDiagnostic> {
     if !value.is_finite() {
         return Err(AuthoringDiagnostic::new(
             path,

--- a/src/authoring/expression.rs
+++ b/src/authoring/expression.rs
@@ -22,11 +22,15 @@ pub(crate) fn evaluate_quantity(
     path: &str,
     expected: Unit,
 ) -> Result<f64, AuthoringDiagnostic> {
-    validate_scene_number(quantity.value, &format!("{path}.value"))?;
-    let evaluated = canonicalize(Evaluated {
-        value: quantity.value,
-        unit: quantity.unit,
-    });
+    let value_path = format!("{path}.value");
+    validate_scene_number(quantity.value, &value_path)?;
+    let evaluated = canonicalize(
+        Evaluated {
+            value: quantity.value,
+            unit: quantity.unit,
+        },
+        &value_path,
+    )?;
     expect_unit(evaluated, path, expected)
 }
 
@@ -76,11 +80,15 @@ fn evaluate(
 ) -> Result<Evaluated, AuthoringDiagnostic> {
     match expression {
         ScalarExpr::Literal { value, unit } => {
-            validate_scene_number(*value, &format!("{path}.value"))?;
-            Ok(canonicalize(Evaluated {
-                value: *value,
-                unit: *unit,
-            }))
+            let value_path = format!("{path}.value");
+            validate_scene_number(*value, &value_path)?;
+            canonicalize(
+                Evaluated {
+                    value: *value,
+                    unit: *unit,
+                },
+                &value_path,
+            )
         }
         ScalarExpr::Parameter { name } => {
             let quantity = scope.get(name).ok_or_else(|| {
@@ -91,10 +99,13 @@ fn evaluate(
                 )
             })?;
             validate_scene_number(quantity.value, path)?;
-            Ok(canonicalize(Evaluated {
-                value: quantity.value,
-                unit: quantity.unit,
-            }))
+            canonicalize(
+                Evaluated {
+                    value: quantity.value,
+                    unit: quantity.unit,
+                },
+                path,
+            )
         }
         ScalarExpr::Add { left, right } => {
             evaluate_binary(left, right, path, scope, |left, right| left + right)
@@ -160,13 +171,25 @@ fn evaluate_binary(
     })
 }
 
-fn canonicalize(evaluated: Evaluated) -> Evaluated {
-    match evaluated.unit {
+fn canonicalize(
+    evaluated: Evaluated,
+    path: &str,
+) -> Result<Evaluated, AuthoringDiagnostic> {
+    let canonical = match evaluated.unit {
         Unit::Degrees => Evaluated {
             value: evaluated.value.to_radians(),
             unit: Unit::Radians,
         },
         _ => evaluated,
+    };
+    validate_scene_number(canonical.value, path)?;
+    Ok(canonical)
+}
+
+fn canonical_unit(unit: Unit) -> Unit {
+    match unit {
+        Unit::Degrees => Unit::Radians,
+        _ => unit,
     }
 }
 
@@ -175,11 +198,7 @@ fn expect_unit(
     path: &str,
     expected: Unit,
 ) -> Result<f64, AuthoringDiagnostic> {
-    let expected = canonicalize(Evaluated {
-        value: 0.0,
-        unit: expected,
-    })
-    .unit;
+    let expected = canonical_unit(expected);
     if evaluated.unit != expected {
         return Err(AuthoringDiagnostic::new(
             path,

--- a/src/authoring/expression.rs
+++ b/src/authoring/expression.rs
@@ -198,11 +198,11 @@ pub(crate) fn validate_scene_number(value: f64, path: &str) -> Result<(), Author
             "numeric values must be finite",
         ));
     }
-    if value.abs() > f64::from(f32::MAX) {
+    if value.abs() > f64::from(f32::MAX) || (value != 0.0 && value as f32 == 0.0) {
         return Err(AuthoringDiagnostic::new(
             path,
             "numeric_out_of_range",
-            "numeric values must fit the canonical f32 scene representation",
+            "numeric values must survive the canonical f32 scene representation",
         ));
     }
     Ok(())

--- a/src/authoring/expression.rs
+++ b/src/authoring/expression.rs
@@ -22,7 +22,7 @@ pub(crate) fn evaluate_quantity(
     path: &str,
     expected: Unit,
 ) -> Result<f64, AuthoringDiagnostic> {
-    ensure_finite(quantity.value, path)?;
+    validate_scene_number(quantity.value, &format!("{path}.value"))?;
     let evaluated = canonicalize(Evaluated {
         value: quantity.value,
         unit: quantity.unit,
@@ -76,7 +76,7 @@ fn evaluate(
 ) -> Result<Evaluated, AuthoringDiagnostic> {
     match expression {
         ScalarExpr::Literal { value, unit } => {
-            ensure_finite(*value, path)?;
+            validate_scene_number(*value, &format!("{path}.value"))?;
             Ok(canonicalize(Evaluated {
                 value: *value,
                 unit: *unit,
@@ -90,7 +90,7 @@ fn evaluate(
                     format!("parameter '{name}' is not defined in this scope"),
                 )
             })?;
-            ensure_finite(quantity.value, path)?;
+            validate_scene_number(quantity.value, path)?;
             Ok(canonicalize(Evaluated {
                 value: quantity.value,
                 unit: quantity.unit,
@@ -103,17 +103,17 @@ fn evaluate(
             evaluate_binary(left, right, path, scope, |left, right| left - right)
         }
         ScalarExpr::Multiply { value, factor } => {
-            ensure_finite(*factor, &format!("{path}.factor"))?;
+            validate_scene_number(*factor, &format!("{path}.factor"))?;
             let evaluated = evaluate(value, &format!("{path}.value"), scope)?;
             let result = evaluated.value * factor;
-            ensure_finite(result, path)?;
+            validate_scene_number(result, path)?;
             Ok(Evaluated {
                 value: result,
                 unit: evaluated.unit,
             })
         }
         ScalarExpr::Divide { value, divisor } => {
-            ensure_finite(*divisor, &format!("{path}.divisor"))?;
+            validate_scene_number(*divisor, &format!("{path}.divisor"))?;
             if *divisor == 0.0 {
                 return Err(AuthoringDiagnostic::new(
                     format!("{path}.divisor"),
@@ -123,7 +123,7 @@ fn evaluate(
             }
             let evaluated = evaluate(value, &format!("{path}.value"), scope)?;
             let result = evaluated.value / divisor;
-            ensure_finite(result, path)?;
+            validate_scene_number(result, path)?;
             Ok(Evaluated {
                 value: result,
                 unit: evaluated.unit,
@@ -153,7 +153,7 @@ fn evaluate_binary(
         ));
     }
     let value = operation(left.value, right.value);
-    ensure_finite(value, path)?;
+    validate_scene_number(value, path)?;
     Ok(Evaluated {
         value,
         unit: left.unit,
@@ -190,14 +190,23 @@ fn expect_unit(
     Ok(evaluated.value)
 }
 
-fn ensure_finite(value: f64, path: &str) -> Result<(), AuthoringDiagnostic> {
-    if value.is_finite() {
-        Ok(())
-    } else {
-        Err(AuthoringDiagnostic::new(
+pub(crate) fn validate_scene_number(
+    value: f64,
+    path: &str,
+) -> Result<(), AuthoringDiagnostic> {
+    if !value.is_finite() {
+        return Err(AuthoringDiagnostic::new(
             path,
             "non_finite",
             "numeric values must be finite",
-        ))
+        ));
     }
+    if value.abs() > f64::from(f32::MAX) {
+        return Err(AuthoringDiagnostic::new(
+            path,
+            "numeric_out_of_range",
+            "numeric values must fit the canonical f32 scene representation",
+        ));
+    }
+    Ok(())
 }

--- a/src/authoring/expression.rs
+++ b/src/authoring/expression.rs
@@ -171,10 +171,7 @@ fn evaluate_binary(
     })
 }
 
-fn canonicalize(
-    evaluated: Evaluated,
-    path: &str,
-) -> Result<Evaluated, AuthoringDiagnostic> {
+fn canonicalize(evaluated: Evaluated, path: &str) -> Result<Evaluated, AuthoringDiagnostic> {
     let canonical = match evaluated.unit {
         Unit::Degrees => Evaluated {
             value: evaluated.value.to_radians(),

--- a/src/authoring/frontend.rs
+++ b/src/authoring/frontend.rs
@@ -1,0 +1,305 @@
+use std::collections::BTreeMap;
+
+use super::expression::validate_scene_number;
+use super::lower;
+use super::spec::{
+    AUTHORING_FORMAT_VERSION, AuthoringArtboard, AuthoringDiagnostic, AuthoringError,
+    AuthoringSpec, BehaviorSection, LoweredAuthoring, MotionSection, Quantity, ScalarExpr,
+    TransformSpec, Unit, VisualNode, VisualSection,
+};
+
+pub fn lower_authoring_json(input: &str) -> Result<LoweredAuthoring, AuthoringError> {
+    let spec = serde_json::from_str::<AuthoringSpec>(input).map_err(|error| {
+        AuthoringError::one(AuthoringDiagnostic::new(
+            "$",
+            "invalid_json",
+            format!(
+                "{error} at line {}, column {}",
+                error.line(),
+                error.column()
+            ),
+        ))
+    })?;
+    lower_authoring(&spec)
+}
+
+pub fn lower_authoring(spec: &AuthoringSpec) -> Result<LoweredAuthoring, AuthoringError> {
+    let numeric_diagnostics = validate_numeric_values(spec);
+    if !numeric_diagnostics.is_empty() {
+        return Err(AuthoringError::many(numeric_diagnostics));
+    }
+
+    validate_component_definitions(spec)?;
+    lower::lower_authoring(spec).map_err(|error| rewrite_error_paths(spec, error))
+}
+
+fn validate_component_definitions(spec: &AuthoringSpec) -> Result<(), AuthoringError> {
+    if spec.authoring_format_version != AUTHORING_FORMAT_VERSION {
+        return Ok(());
+    }
+
+    for (component_index, component) in spec.components.iter().enumerate() {
+        let validation_spec = AuthoringSpec {
+            authoring_format_version: spec.authoring_format_version,
+            artboard: AuthoringArtboard {
+                id: format!("__authoring_component_validation_{component_index}"),
+                width: Quantity {
+                    value: 1.0,
+                    unit: Unit::Px,
+                },
+                height: Quantity {
+                    value: 1.0,
+                    unit: Unit::Px,
+                },
+            },
+            parameters: spec.parameters.clone(),
+            components: spec.components.clone(),
+            visual: VisualSection {
+                nodes: vec![VisualNode::Instance {
+                    id: "__component_root".to_string(),
+                    component: component.id.clone(),
+                    overrides: BTreeMap::new(),
+                    transform: TransformSpec::default(),
+                }],
+            },
+            motion: MotionSection::default(),
+            behavior: BehaviorSection::default(),
+        };
+
+        if let Err(error) = lower::lower_authoring(&validation_spec) {
+            let mut error = rewrite_error_paths(&validation_spec, error);
+            for diagnostic in &mut error.diagnostics {
+                if diagnostic.path == "$.lowered_scene" {
+                    diagnostic.path = format!("$.components[{component_index}].visual");
+                    diagnostic.code = "invalid_component_scene".to_string();
+                    diagnostic.message = format!(
+                        "component '{}' does not lower to a canonical SceneSpec graph: {}",
+                        component.id, diagnostic.message
+                    );
+                }
+            }
+            return Err(error);
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_numeric_values(spec: &AuthoringSpec) -> Vec<AuthoringDiagnostic> {
+    let mut diagnostics = Vec::new();
+    validate_quantity(
+        spec.artboard.width,
+        "$.artboard.width",
+        &mut diagnostics,
+    );
+    validate_quantity(
+        spec.artboard.height,
+        "$.artboard.height",
+        &mut diagnostics,
+    );
+    validate_quantity_map(&spec.parameters, "$.parameters", &mut diagnostics);
+
+    for (component_index, component) in spec.components.iter().enumerate() {
+        let component_path = format!("$.components[{component_index}]");
+        validate_quantity_map(
+            &component.parameters,
+            &format!("{component_path}.parameters"),
+            &mut diagnostics,
+        );
+        validate_nodes(
+            &component.visual,
+            &format!("{component_path}.visual"),
+            &mut diagnostics,
+        );
+    }
+    validate_nodes(&spec.visual.nodes, "$.visual.nodes", &mut diagnostics);
+    diagnostics
+}
+
+fn validate_quantity_map(
+    quantities: &BTreeMap<String, Quantity>,
+    path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    for (name, quantity) in quantities {
+        validate_quantity(*quantity, &format!("{path}.{name}"), diagnostics);
+    }
+}
+
+fn validate_quantity(
+    quantity: Quantity,
+    path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    if let Err(diagnostic) = validate_scene_number(quantity.value, &format!("{path}.value")) {
+        diagnostics.push(diagnostic);
+    }
+}
+
+fn validate_nodes(
+    nodes: &[VisualNode],
+    list_path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    for (index, node) in nodes.iter().enumerate() {
+        validate_node(node, &format!("{list_path}[{index}]"), diagnostics);
+    }
+}
+
+fn validate_node(
+    node: &VisualNode,
+    path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    match node {
+        VisualNode::Ellipse {
+            width,
+            height,
+            transform,
+            ..
+        } => {
+            validate_expression(width, &format!("{path}.width"), diagnostics);
+            validate_expression(height, &format!("{path}.height"), diagnostics);
+            validate_transform(transform, &format!("{path}.transform"), diagnostics);
+        }
+        VisualNode::Rectangle {
+            width,
+            height,
+            corner_radius,
+            transform,
+            ..
+        } => {
+            validate_expression(width, &format!("{path}.width"), diagnostics);
+            validate_expression(height, &format!("{path}.height"), diagnostics);
+            if let Some(corner_radius) = corner_radius {
+                validate_expression(
+                    corner_radius,
+                    &format!("{path}.corner_radius"),
+                    diagnostics,
+                );
+            }
+            validate_transform(transform, &format!("{path}.transform"), diagnostics);
+        }
+        VisualNode::Group {
+            transform,
+            children,
+            ..
+        } => {
+            validate_transform(transform, &format!("{path}.transform"), diagnostics);
+            validate_nodes(children, &format!("{path}.children"), diagnostics);
+        }
+        VisualNode::Instance {
+            overrides,
+            transform,
+            ..
+        } => {
+            validate_quantity_map(overrides, &format!("{path}.overrides"), diagnostics);
+            validate_transform(transform, &format!("{path}.transform"), diagnostics);
+        }
+        VisualNode::RawSceneObject { .. } => {}
+    }
+}
+
+fn validate_transform(
+    transform: &TransformSpec,
+    path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    for (name, expression) in [
+        ("x", transform.x.as_ref()),
+        ("y", transform.y.as_ref()),
+        ("rotation", transform.rotation.as_ref()),
+        ("scale_x", transform.scale_x.as_ref()),
+        ("scale_y", transform.scale_y.as_ref()),
+    ] {
+        if let Some(expression) = expression {
+            validate_expression(expression, &format!("{path}.{name}"), diagnostics);
+        }
+    }
+}
+
+fn validate_expression(
+    expression: &ScalarExpr,
+    path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    match expression {
+        ScalarExpr::Literal { value, .. } => {
+            if let Err(diagnostic) = validate_scene_number(*value, &format!("{path}.value")) {
+                diagnostics.push(diagnostic);
+            }
+        }
+        ScalarExpr::Parameter { .. } => {}
+        ScalarExpr::Add { left, right } | ScalarExpr::Subtract { left, right } => {
+            validate_expression(left, &format!("{path}.left"), diagnostics);
+            validate_expression(right, &format!("{path}.right"), diagnostics);
+        }
+        ScalarExpr::Multiply { value, factor } => {
+            validate_expression(value, &format!("{path}.value"), diagnostics);
+            if let Err(diagnostic) = validate_scene_number(*factor, &format!("{path}.factor")) {
+                diagnostics.push(diagnostic);
+            }
+        }
+        ScalarExpr::Divide { value, divisor } => {
+            validate_expression(value, &format!("{path}.value"), diagnostics);
+            if let Err(diagnostic) = validate_scene_number(*divisor, &format!("{path}.divisor")) {
+                diagnostics.push(diagnostic);
+            }
+        }
+    }
+}
+
+fn rewrite_error_paths(spec: &AuthoringSpec, mut error: AuthoringError) -> AuthoringError {
+    for diagnostic in &mut error.diagnostics {
+        if let Some(path) = resolve_expanded_path(spec, &diagnostic.path) {
+            diagnostic.path = path;
+        }
+    }
+    error
+}
+
+fn resolve_expanded_path(spec: &AuthoringSpec, path: &str) -> Option<String> {
+    let (root_index, mut remainder) = take_index(path, "$.visual.nodes[")?;
+    let mut node = spec.visual.nodes.get(root_index)?;
+    let mut resolved = format!("$.visual.nodes[{root_index}]");
+
+    loop {
+        if let Some((expanded_index, rest)) = take_index(remainder, ".expanded[") {
+            let VisualNode::Instance { component, .. } = node else {
+                return None;
+            };
+            let component_index = spec
+                .components
+                .iter()
+                .position(|candidate| candidate.id == *component)?;
+            node = spec
+                .components
+                .get(component_index)?
+                .visual
+                .get(expanded_index)?;
+            resolved = format!("$.components[{component_index}].visual[{expanded_index}]");
+            remainder = rest;
+            continue;
+        }
+
+        if let Some((child_index, rest)) = take_index(remainder, ".children[") {
+            let VisualNode::Group { children, .. } = node else {
+                return None;
+            };
+            node = children.get(child_index)?;
+            resolved.push_str(&format!(".children[{child_index}]"));
+            remainder = rest;
+            continue;
+        }
+
+        resolved.push_str(remainder);
+        return Some(resolved);
+    }
+}
+
+fn take_index<'a>(input: &'a str, prefix: &str) -> Option<(usize, &'a str)> {
+    let input = input.strip_prefix(prefix)?;
+    let close = input.find(']')?;
+    let index = input[..close].parse().ok()?;
+    Some((index, &input[close + 1..]))
+}

--- a/src/authoring/frontend.rs
+++ b/src/authoring/frontend.rs
@@ -21,15 +21,14 @@ pub fn lower_authoring_json(input: &str) -> Result<LoweredAuthoring, AuthoringEr
         ))
     })?;
     validate_authoring(&spec)?;
-    let lowered = lower::lower_authoring_json(input)
-        .map_err(|error| rewrite_error_paths(&spec, error))?;
+    let lowered =
+        lower::lower_authoring_json(input).map_err(|error| rewrite_error_paths(&spec, error))?;
     validate_runtime_names(lowered)
 }
 
 pub fn lower_authoring(spec: &AuthoringSpec) -> Result<LoweredAuthoring, AuthoringError> {
     validate_authoring(spec)?;
-    let lowered =
-        lower::lower_authoring(spec).map_err(|error| rewrite_error_paths(spec, error))?;
+    let lowered = lower::lower_authoring(spec).map_err(|error| rewrite_error_paths(spec, error))?;
     validate_runtime_names(lowered)
 }
 
@@ -47,16 +46,12 @@ fn validate_authoring(spec: &AuthoringSpec) -> Result<(), AuthoringError> {
     validate_component_definitions(spec)
 }
 
-fn validate_runtime_names(
-    lowered: LoweredAuthoring,
-) -> Result<LoweredAuthoring, AuthoringError> {
+fn validate_runtime_names(lowered: LoweredAuthoring) -> Result<LoweredAuthoring, AuthoringError> {
     let mut names = HashSet::new();
     for entry in &lowered.source_map.entries {
         for name in &entry.runtime_names {
             if !names.insert(name.as_str()) {
-                let path = if entry
-                    .authored_path
-                    .starts_with("$.motion.raw_animations[")
+                let path = if entry.authored_path.starts_with("$.motion.raw_animations[")
                     || entry
                         .authored_path
                         .starts_with("$.behavior.raw_state_machines[")

--- a/src/authoring/frontend.rs
+++ b/src/authoring/frontend.rs
@@ -38,6 +38,8 @@ fn validate_authoring(spec: &AuthoringSpec) -> Result<(), AuthoringError> {
         return Err(AuthoringError::many(name_diagnostics));
     }
 
+    validate_raw_fragment_runtime_names(spec)?;
+
     let numeric_diagnostics = validate_numeric_values(spec);
     if !numeric_diagnostics.is_empty() {
         return Err(AuthoringError::many(numeric_diagnostics));
@@ -69,6 +71,56 @@ fn validate_runtime_names(lowered: LoweredAuthoring) -> Result<LoweredAuthoring,
         }
     }
     Ok(lowered)
+}
+
+fn validate_raw_fragment_runtime_names(spec: &AuthoringSpec) -> Result<(), AuthoringError> {
+    let mut names = HashSet::new();
+    for (fragments, list_path) in [
+        (
+            spec.motion.raw_animations.as_slice(),
+            "$.motion.raw_animations",
+        ),
+        (
+            spec.behavior.raw_state_machines.as_slice(),
+            "$.behavior.raw_state_machines",
+        ),
+    ] {
+        for (index, fragment) in fragments.iter().enumerate() {
+            let mut declared_names = Vec::new();
+            collect_declared_names(&fragment.value, &mut declared_names);
+            for name in declared_names {
+                if !names.insert(name.clone()) {
+                    return Err(AuthoringError::one(AuthoringDiagnostic::new(
+                        format!("{list_path}[{index}].value"),
+                        "runtime_name_collision",
+                        format!("runtime name '{name}' is declared more than once"),
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_declared_names(value: &serde_json::Value, names: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(object) => {
+            if let Some(name) = object.get("name").and_then(serde_json::Value::as_str) {
+                names.push(name.to_string());
+            }
+            if let Some(serde_json::Value::Array(children)) = object.get("children") {
+                for child in children {
+                    collect_declared_names(child, names);
+                }
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                collect_declared_names(child, names);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn validate_authored_names(spec: &AuthoringSpec) -> Vec<AuthoringDiagnostic> {

--- a/src/authoring/frontend.rs
+++ b/src/authoring/frontend.rs
@@ -87,16 +87,8 @@ fn validate_component_definitions(spec: &AuthoringSpec) -> Result<(), AuthoringE
 
 fn validate_numeric_values(spec: &AuthoringSpec) -> Vec<AuthoringDiagnostic> {
     let mut diagnostics = Vec::new();
-    validate_quantity(
-        spec.artboard.width,
-        "$.artboard.width",
-        &mut diagnostics,
-    );
-    validate_quantity(
-        spec.artboard.height,
-        "$.artboard.height",
-        &mut diagnostics,
-    );
+    validate_quantity(spec.artboard.width, "$.artboard.width", &mut diagnostics);
+    validate_quantity(spec.artboard.height, "$.artboard.height", &mut diagnostics);
     validate_quantity_map(&spec.parameters, "$.parameters", &mut diagnostics);
 
     for (component_index, component) in spec.components.iter().enumerate() {
@@ -126,11 +118,7 @@ fn validate_quantity_map(
     }
 }
 
-fn validate_quantity(
-    quantity: Quantity,
-    path: &str,
-    diagnostics: &mut Vec<AuthoringDiagnostic>,
-) {
+fn validate_quantity(quantity: Quantity, path: &str, diagnostics: &mut Vec<AuthoringDiagnostic>) {
     if let Err(diagnostic) = validate_scene_number(quantity.value, &format!("{path}.value")) {
         diagnostics.push(diagnostic);
     }
@@ -146,11 +134,7 @@ fn validate_nodes(
     }
 }
 
-fn validate_node(
-    node: &VisualNode,
-    path: &str,
-    diagnostics: &mut Vec<AuthoringDiagnostic>,
-) {
+fn validate_node(node: &VisualNode, path: &str, diagnostics: &mut Vec<AuthoringDiagnostic>) {
     match node {
         VisualNode::Ellipse {
             width,
@@ -172,11 +156,7 @@ fn validate_node(
             validate_expression(width, &format!("{path}.width"), diagnostics);
             validate_expression(height, &format!("{path}.height"), diagnostics);
             if let Some(corner_radius) = corner_radius {
-                validate_expression(
-                    corner_radius,
-                    &format!("{path}.corner_radius"),
-                    diagnostics,
-                );
+                validate_expression(corner_radius, &format!("{path}.corner_radius"), diagnostics);
             }
             validate_transform(transform, &format!("{path}.transform"), diagnostics);
         }

--- a/src/authoring/frontend.rs
+++ b/src/authoring/frontend.rs
@@ -1,11 +1,11 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use super::expression::validate_scene_number;
 use super::lower;
 use super::spec::{
     AUTHORING_FORMAT_VERSION, AuthoringArtboard, AuthoringDiagnostic, AuthoringError,
-    AuthoringSpec, BehaviorSection, LoweredAuthoring, MotionSection, Quantity, ScalarExpr,
-    TransformSpec, Unit, VisualNode, VisualSection,
+    AuthoringSpec, BehaviorSection, LoweredAuthoring, MotionSection, Quantity, RawSceneFragment,
+    ScalarExpr, TransformSpec, Unit, VisualNode, VisualSection,
 };
 
 pub fn lower_authoring_json(input: &str) -> Result<LoweredAuthoring, AuthoringError> {
@@ -20,17 +20,176 @@ pub fn lower_authoring_json(input: &str) -> Result<LoweredAuthoring, AuthoringEr
             ),
         ))
     })?;
-    lower_authoring(&spec)
+    validate_authoring(&spec)?;
+    let lowered = lower::lower_authoring_json(input)
+        .map_err(|error| rewrite_error_paths(&spec, error))?;
+    validate_runtime_names(lowered)
 }
 
 pub fn lower_authoring(spec: &AuthoringSpec) -> Result<LoweredAuthoring, AuthoringError> {
+    validate_authoring(spec)?;
+    let lowered =
+        lower::lower_authoring(spec).map_err(|error| rewrite_error_paths(spec, error))?;
+    validate_runtime_names(lowered)
+}
+
+fn validate_authoring(spec: &AuthoringSpec) -> Result<(), AuthoringError> {
+    let name_diagnostics = validate_authored_names(spec);
+    if !name_diagnostics.is_empty() {
+        return Err(AuthoringError::many(name_diagnostics));
+    }
+
     let numeric_diagnostics = validate_numeric_values(spec);
     if !numeric_diagnostics.is_empty() {
         return Err(AuthoringError::many(numeric_diagnostics));
     }
 
-    validate_component_definitions(spec)?;
-    lower::lower_authoring(spec).map_err(|error| rewrite_error_paths(spec, error))
+    validate_component_definitions(spec)
+}
+
+fn validate_runtime_names(
+    lowered: LoweredAuthoring,
+) -> Result<LoweredAuthoring, AuthoringError> {
+    let mut names = HashSet::new();
+    for entry in &lowered.source_map.entries {
+        for name in &entry.runtime_names {
+            if !names.insert(name.as_str()) {
+                let path = if entry
+                    .authored_path
+                    .starts_with("$.motion.raw_animations[")
+                    || entry
+                        .authored_path
+                        .starts_with("$.behavior.raw_state_machines[")
+                {
+                    format!("{}.value", entry.authored_path)
+                } else {
+                    entry.authored_path.clone()
+                };
+                return Err(AuthoringError::one(AuthoringDiagnostic::new(
+                    path,
+                    "runtime_name_collision",
+                    format!("runtime name '{name}' is generated or declared more than once"),
+                )));
+            }
+        }
+    }
+    Ok(lowered)
+}
+
+fn validate_authored_names(spec: &AuthoringSpec) -> Vec<AuthoringDiagnostic> {
+    let mut diagnostics = Vec::new();
+    validate_id(&spec.artboard.id, "$.artboard.id", &mut diagnostics);
+    validate_parameter_names(&spec.parameters, "$.parameters", &mut diagnostics);
+
+    for (component_index, component) in spec.components.iter().enumerate() {
+        let component_path = format!("$.components[{component_index}]");
+        validate_id(
+            &component.id,
+            &format!("{component_path}.id"),
+            &mut diagnostics,
+        );
+        validate_parameter_names(
+            &component.parameters,
+            &format!("{component_path}.parameters"),
+            &mut diagnostics,
+        );
+        validate_node_names(
+            &component.visual,
+            &format!("{component_path}.visual"),
+            &mut diagnostics,
+        );
+    }
+
+    validate_node_names(&spec.visual.nodes, "$.visual.nodes", &mut diagnostics);
+    validate_fragment_names(
+        &spec.motion.raw_animations,
+        "$.motion.raw_animations",
+        &mut diagnostics,
+    );
+    validate_fragment_names(
+        &spec.behavior.raw_state_machines,
+        "$.behavior.raw_state_machines",
+        &mut diagnostics,
+    );
+    diagnostics
+}
+
+fn validate_id(id: &str, path: &str, diagnostics: &mut Vec<AuthoringDiagnostic>) {
+    if id.trim().is_empty() {
+        diagnostics.push(AuthoringDiagnostic::new(
+            path,
+            "invalid_id",
+            "authored ids must not be empty",
+        ));
+    }
+    if id.contains('/') {
+        diagnostics.push(AuthoringDiagnostic::new(
+            path,
+            "invalid_id",
+            "authored ids must not contain the reserved '/' source-map separator",
+        ));
+    }
+}
+
+fn validate_parameter_names(
+    parameters: &BTreeMap<String, Quantity>,
+    path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    for name in parameters.keys() {
+        if !is_parameter_name(name) {
+            diagnostics.push(AuthoringDiagnostic::new(
+                path,
+                "invalid_parameter",
+                format!(
+                    "parameter name '{name}' must contain only ASCII letters, digits, '_' or '-'"
+                ),
+            ));
+        }
+    }
+}
+
+fn is_parameter_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+}
+
+fn validate_node_names(
+    nodes: &[VisualNode],
+    list_path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    for (index, node) in nodes.iter().enumerate() {
+        let path = format!("{list_path}[{index}]");
+        validate_id(node.id(), &format!("{path}.id"), diagnostics);
+        match node {
+            VisualNode::Group { children, .. } => {
+                validate_node_names(children, &format!("{path}.children"), diagnostics);
+            }
+            VisualNode::Instance { overrides, .. } => {
+                validate_parameter_names(overrides, &format!("{path}.overrides"), diagnostics);
+            }
+            VisualNode::Ellipse { .. }
+            | VisualNode::Rectangle { .. }
+            | VisualNode::RawSceneObject { .. } => {}
+        }
+    }
+}
+
+fn validate_fragment_names(
+    fragments: &[RawSceneFragment],
+    list_path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    for (index, fragment) in fragments.iter().enumerate() {
+        validate_id(
+            &fragment.id,
+            &format!("{list_path}[{index}].id"),
+            diagnostics,
+        );
+    }
 }
 
 fn validate_component_definitions(spec: &AuthoringSpec) -> Result<(), AuthoringError> {
@@ -52,7 +211,7 @@ fn validate_component_definitions(spec: &AuthoringSpec) -> Result<(), AuthoringE
                     unit: Unit::Px,
                 },
             },
-            parameters: spec.parameters.clone(),
+            parameters: BTreeMap::new(),
             components: spec.components.clone(),
             visual: VisualSection {
                 nodes: vec![VisualNode::Instance {

--- a/src/authoring/limits.rs
+++ b/src/authoring/limits.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use super::spec::{AuthoringDiagnostic, AuthoringError, AuthoringSpec, ComponentSpec, VisualNode};
 
 const MAX_COMPONENT_EXPANSION_DEPTH: usize = 64;
+const MAX_GENERATED_COMPONENT_NODES: usize = 10_000;
 
 #[derive(Clone, Copy)]
 struct ComponentRef<'a> {
@@ -14,9 +15,11 @@ struct WorkItem<'a> {
     node: &'a VisualNode,
     path: String,
     active_components: Vec<usize>,
+    generated: bool,
+    budget_path: String,
 }
 
-pub(crate) fn validate_component_expansion_depth(
+pub(crate) fn validate_component_expansion(
     spec: &AuthoringSpec,
 ) -> Result<(), AuthoringError> {
     let mut components = HashMap::new();
@@ -36,18 +39,23 @@ pub(crate) fn validate_component_expansion_depth(
     }
 
     for (index, component) in spec.components.iter().enumerate() {
+        let mut generated_nodes = 0;
         validate_nodes(
             &component.visual,
             &format!("$.components[{index}].visual"),
             vec![index],
             &components,
+            &mut generated_nodes,
         )?;
     }
+
+    let mut generated_nodes = 0;
     validate_nodes(
         &spec.visual.nodes,
         "$.visual.nodes",
         Vec::new(),
         &components,
+        &mut generated_nodes,
     )
 }
 
@@ -56,17 +64,40 @@ fn validate_nodes<'a>(
     list_path: &str,
     active_components: Vec<usize>,
     components: &HashMap<&'a str, ComponentRef<'a>>,
+    generated_nodes: &mut usize,
 ) -> Result<(), AuthoringError> {
     let mut work = Vec::new();
-    push_nodes(&mut work, nodes, list_path, &active_components);
+    push_nodes(
+        &mut work,
+        nodes,
+        list_path,
+        &active_components,
+        false,
+        list_path,
+    );
 
     while let Some(item) = work.pop() {
+        if item.generated {
+            *generated_nodes += 1;
+            if *generated_nodes > MAX_GENERATED_COMPONENT_NODES {
+                return Err(AuthoringError::one(AuthoringDiagnostic::new(
+                    item.budget_path,
+                    "component_expansion_node_limit",
+                    format!(
+                        "component expansion exceeds the maximum generated-node budget of {MAX_GENERATED_COMPONENT_NODES}"
+                    ),
+                )));
+            }
+        }
+
         match item.node {
             VisualNode::Group { children, .. } => push_nodes(
                 &mut work,
                 children,
                 &format!("{}.children", item.path),
                 &item.active_components,
+                item.generated,
+                &item.budget_path,
             ),
             VisualNode::Instance { component, .. } => {
                 let Some(component_ref) = components.get(component.as_str()).copied() else {
@@ -87,11 +118,14 @@ fn validate_nodes<'a>(
 
                 let mut next_active = item.active_components;
                 next_active.push(component_ref.index);
+                let expansion_path = format!("{}.component", item.path);
                 push_nodes(
                     &mut work,
                     &component_ref.spec.visual,
                     &format!("$.components[{}].visual", component_ref.index),
                     &next_active,
+                    true,
+                    &expansion_path,
                 );
             }
             VisualNode::Ellipse { .. }
@@ -108,12 +142,16 @@ fn push_nodes<'a>(
     nodes: &'a [VisualNode],
     list_path: &str,
     active_components: &[usize],
+    generated: bool,
+    budget_path: &str,
 ) {
     for (index, node) in nodes.iter().enumerate().rev() {
         work.push(WorkItem {
             node,
             path: format!("{list_path}[{index}]"),
             active_components: active_components.to_vec(),
+            generated,
+            budget_path: budget_path.to_string(),
         });
     }
 }

--- a/src/authoring/limits.rs
+++ b/src/authoring/limits.rs
@@ -58,12 +58,7 @@ fn validate_nodes<'a>(
     components: &HashMap<&'a str, ComponentRef<'a>>,
 ) -> Result<(), AuthoringError> {
     let mut work = Vec::new();
-    push_nodes(
-        &mut work,
-        nodes,
-        list_path,
-        &active_components,
-    );
+    push_nodes(&mut work, nodes, list_path, &active_components);
 
     while let Some(item) = work.pop() {
         match item.node {

--- a/src/authoring/limits.rs
+++ b/src/authoring/limits.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+
+use super::spec::{AuthoringDiagnostic, AuthoringError, AuthoringSpec, ComponentSpec, VisualNode};
+
+const MAX_COMPONENT_EXPANSION_DEPTH: usize = 64;
+
+#[derive(Clone, Copy)]
+struct ComponentRef<'a> {
+    index: usize,
+    spec: &'a ComponentSpec,
+}
+
+struct WorkItem<'a> {
+    node: &'a VisualNode,
+    path: String,
+    active_components: Vec<usize>,
+}
+
+pub(crate) fn validate_component_expansion_depth(
+    spec: &AuthoringSpec,
+) -> Result<(), AuthoringError> {
+    let mut components = HashMap::new();
+    for (index, component) in spec.components.iter().enumerate() {
+        if components
+            .insert(
+                component.id.as_str(),
+                ComponentRef {
+                    index,
+                    spec: component,
+                },
+            )
+            .is_some()
+        {
+            return Ok(());
+        }
+    }
+
+    for (index, component) in spec.components.iter().enumerate() {
+        validate_nodes(
+            &component.visual,
+            &format!("$.components[{index}].visual"),
+            vec![index],
+            &components,
+        )?;
+    }
+    validate_nodes(
+        &spec.visual.nodes,
+        "$.visual.nodes",
+        Vec::new(),
+        &components,
+    )
+}
+
+fn validate_nodes<'a>(
+    nodes: &'a [VisualNode],
+    list_path: &str,
+    active_components: Vec<usize>,
+    components: &HashMap<&'a str, ComponentRef<'a>>,
+) -> Result<(), AuthoringError> {
+    let mut work = Vec::new();
+    push_nodes(
+        &mut work,
+        nodes,
+        list_path,
+        &active_components,
+    );
+
+    while let Some(item) = work.pop() {
+        match item.node {
+            VisualNode::Group { children, .. } => push_nodes(
+                &mut work,
+                children,
+                &format!("{}.children", item.path),
+                &item.active_components,
+            ),
+            VisualNode::Instance { component, .. } => {
+                let Some(component_ref) = components.get(component.as_str()).copied() else {
+                    continue;
+                };
+                if item.active_components.contains(&component_ref.index) {
+                    continue;
+                }
+                if item.active_components.len() >= MAX_COMPONENT_EXPANSION_DEPTH {
+                    return Err(AuthoringError::one(AuthoringDiagnostic::new(
+                        format!("{}.component", item.path),
+                        "component_expansion_depth_limit",
+                        format!(
+                            "component expansion exceeds the maximum depth of {MAX_COMPONENT_EXPANSION_DEPTH}"
+                        ),
+                    )));
+                }
+
+                let mut next_active = item.active_components;
+                next_active.push(component_ref.index);
+                push_nodes(
+                    &mut work,
+                    &component_ref.spec.visual,
+                    &format!("$.components[{}].visual", component_ref.index),
+                    &next_active,
+                );
+            }
+            VisualNode::Ellipse { .. }
+            | VisualNode::Rectangle { .. }
+            | VisualNode::RawSceneObject { .. } => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn push_nodes<'a>(
+    work: &mut Vec<WorkItem<'a>>,
+    nodes: &'a [VisualNode],
+    list_path: &str,
+    active_components: &[usize],
+) {
+    for (index, node) in nodes.iter().enumerate().rev() {
+        work.push(WorkItem {
+            node,
+            path: format!("{list_path}[{index}]"),
+            active_components: active_components.to_vec(),
+        });
+    }
+}

--- a/src/authoring/limits.rs
+++ b/src/authoring/limits.rs
@@ -19,7 +19,7 @@ struct WorkItem<'a> {
     budget_path: String,
 }
 
-pub(crate) fn validate_component_expansion(
+pub(crate) fn validate_component_expansion_depth(
     spec: &AuthoringSpec,
 ) -> Result<(), AuthoringError> {
     let mut components = HashMap::new();

--- a/src/authoring/lower.rs
+++ b/src/authoring/lower.rs
@@ -135,11 +135,8 @@ impl<'a> Lowerer<'a> {
         }
 
         let artboard_name = runtime_name(&[self.spec.artboard.id.clone()], "artboard");
-        self.register_runtime_names(
-            std::slice::from_ref(&artboard_name),
-            "$.artboard.id",
-        )
-        .map_err(AuthoringError::one)?;
+        self.register_runtime_names(std::slice::from_ref(&artboard_name), "$.artboard.id")
+            .map_err(AuthoringError::one)?;
         self.source_map.entries.push(SourceMapEntry {
             authored_id: self.spec.artboard.id.clone(),
             authored_path: "$.artboard".to_string(),
@@ -196,10 +193,7 @@ impl<'a> Lowerer<'a> {
                 object.insert("animations".to_string(), Value::Array(animations));
             }
             if !state_machines.is_empty() {
-                object.insert(
-                    "state_machines".to_string(),
-                    Value::Array(state_machines),
-                );
+                object.insert("state_machines".to_string(), Value::Array(state_machines));
             }
         }
         let scene = json!({
@@ -288,11 +282,8 @@ impl<'a> Lowerer<'a> {
                 ..
             } => {
                 validate_sibling_ids_result(children, &format!("{authored_path}.children"))?;
-                let transform_values = evaluate_transform(
-                    transform,
-                    &format!("{authored_path}.transform"),
-                    scope,
-                )?;
+                let transform_values =
+                    evaluate_transform(transform, &format!("{authored_path}.transform"), scope)?;
                 let wrapper_name = runtime_name(&runtime_segments, "group");
                 self.register_runtime_names(
                     std::slice::from_ref(&wrapper_name),
@@ -381,11 +372,8 @@ impl<'a> Lowerer<'a> {
                     }
                 }
 
-                let transform_values = evaluate_transform(
-                    transform,
-                    &format!("{authored_path}.transform"),
-                    scope,
-                )?;
+                let transform_values =
+                    evaluate_transform(transform, &format!("{authored_path}.transform"), scope)?;
                 let wrapper_name = runtime_name(&runtime_segments, "instance");
                 self.register_runtime_names(
                     std::slice::from_ref(&wrapper_name),
@@ -454,16 +442,8 @@ impl<'a> Lowerer<'a> {
                 }
                 let mut runtime_names = Vec::new();
                 let mut scene_paths = Vec::new();
-                collect_named_paths(
-                    object,
-                    &scene_path,
-                    &mut runtime_names,
-                    &mut scene_paths,
-                );
-                self.register_runtime_names(
-                    &runtime_names,
-                    &format!("{authored_path}.object"),
-                )?;
+                collect_named_paths(object, &scene_path, &mut runtime_names, &mut scene_paths);
+                self.register_runtime_names(&runtime_names, &format!("{authored_path}.object"))?;
                 self.source_map.entries.push(SourceMapEntry {
                     authored_id,
                     authored_path,

--- a/src/authoring/lower.rs
+++ b/src/authoring/lower.rs
@@ -555,13 +555,13 @@ impl<'a> Lowerer<'a> {
             "origin_x": 0.5,
             "origin_y": 0.5
         });
-        if geometry_type == "rectangle" {
-            if let Some(object) = geometry.as_object_mut() {
-                object.insert(
-                    "corner_radius".to_string(),
-                    corner_radius.map_or(Value::Null, Value::from),
-                );
-            }
+        if geometry_type == "rectangle"
+            && let Some(object) = geometry.as_object_mut()
+        {
+            object.insert(
+                "corner_radius".to_string(),
+                corner_radius.map_or(Value::Null, Value::from),
+            );
         }
 
         Ok(json!({

--- a/src/authoring/lower.rs
+++ b/src/authoring/lower.rs
@@ -1,0 +1,815 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use serde_json::{Value, json};
+
+use crate::builder::{SceneSpec, build_scene};
+
+use super::expression::{evaluate_expression, evaluate_quantity, evaluate_transform};
+use super::spec::{
+    AUTHORING_FORMAT_VERSION, AuthoringDiagnostic, AuthoringError, AuthoringSourceMap,
+    AuthoringSpec, ComponentSpec, LoweredAuthoring, Quantity, SourceMapEntry, Unit, VisualNode,
+};
+
+#[derive(Clone, Copy)]
+struct ComponentRef<'a> {
+    index: usize,
+    spec: &'a ComponentSpec,
+}
+
+struct Lowerer<'a> {
+    spec: &'a AuthoringSpec,
+    components: HashMap<&'a str, ComponentRef<'a>>,
+    source_map: AuthoringSourceMap,
+    runtime_names: HashSet<String>,
+}
+
+pub fn lower_authoring_json(input: &str) -> Result<LoweredAuthoring, AuthoringError> {
+    let spec = serde_json::from_str::<AuthoringSpec>(input).map_err(|error| {
+        AuthoringError::one(AuthoringDiagnostic::new(
+            "$",
+            "invalid_json",
+            format!(
+                "{error} at line {}, column {}",
+                error.line(),
+                error.column()
+            ),
+        ))
+    })?;
+    lower_authoring(&spec)
+}
+
+pub fn lower_authoring(spec: &AuthoringSpec) -> Result<LoweredAuthoring, AuthoringError> {
+    let mut diagnostics = Vec::new();
+    if spec.authoring_format_version != AUTHORING_FORMAT_VERSION {
+        diagnostics.push(AuthoringDiagnostic::new(
+            "$.authoring_format_version",
+            "unsupported_version",
+            format!(
+                "AuthoringSpec version {} is unsupported; expected {AUTHORING_FORMAT_VERSION}",
+                spec.authoring_format_version
+            ),
+        ));
+    }
+    validate_id(&spec.artboard.id, "$.artboard.id", &mut diagnostics);
+    validate_parameters(&spec.parameters, "$.parameters", &mut diagnostics);
+
+    let mut components = HashMap::new();
+    for (index, component) in spec.components.iter().enumerate() {
+        let component_path = format!("$.components[{index}]");
+        validate_id(
+            &component.id,
+            &format!("{component_path}.id"),
+            &mut diagnostics,
+        );
+        validate_parameters(
+            &component.parameters,
+            &format!("{component_path}.parameters"),
+            &mut diagnostics,
+        );
+        validate_sibling_ids(
+            &component.visual,
+            &format!("{component_path}.visual"),
+            &mut diagnostics,
+        );
+        if components
+            .insert(
+                component.id.as_str(),
+                ComponentRef {
+                    index,
+                    spec: component,
+                },
+            )
+            .is_some()
+        {
+            diagnostics.push(AuthoringDiagnostic::new(
+                format!("{component_path}.id"),
+                "duplicate_component",
+                format!("component id '{}' is duplicated", component.id),
+            ));
+        }
+    }
+    validate_sibling_ids(&spec.visual.nodes, "$.visual.nodes", &mut diagnostics);
+    validate_fragment_ids(
+        &spec.motion.raw_animations,
+        "$.motion.raw_animations",
+        &mut diagnostics,
+    );
+    validate_fragment_ids(
+        &spec.behavior.raw_state_machines,
+        "$.behavior.raw_state_machines",
+        &mut diagnostics,
+    );
+
+    if !diagnostics.is_empty() {
+        return Err(AuthoringError::many(diagnostics));
+    }
+
+    Lowerer {
+        spec,
+        components,
+        source_map: AuthoringSourceMap::default(),
+        runtime_names: HashSet::new(),
+    }
+    .lower()
+}
+
+impl<'a> Lowerer<'a> {
+    fn lower(mut self) -> Result<LoweredAuthoring, AuthoringError> {
+        let width = evaluate_quantity(self.spec.artboard.width, "$.artboard.width", Unit::Px)
+            .map_err(AuthoringError::one)?;
+        let height = evaluate_quantity(self.spec.artboard.height, "$.artboard.height", Unit::Px)
+            .map_err(AuthoringError::one)?;
+        if width <= 0.0 {
+            return Err(AuthoringError::one(AuthoringDiagnostic::new(
+                "$.artboard.width",
+                "invalid_dimension",
+                "artboard width must be greater than zero",
+            )));
+        }
+        if height <= 0.0 {
+            return Err(AuthoringError::one(AuthoringDiagnostic::new(
+                "$.artboard.height",
+                "invalid_dimension",
+                "artboard height must be greater than zero",
+            )));
+        }
+
+        let artboard_name = runtime_name(&[self.spec.artboard.id.clone()], "artboard");
+        self.register_runtime_names(
+            std::slice::from_ref(&artboard_name),
+            "$.artboard.id",
+        )
+        .map_err(AuthoringError::one)?;
+        self.source_map.entries.push(SourceMapEntry {
+            authored_id: self.spec.artboard.id.clone(),
+            authored_path: "$.artboard".to_string(),
+            definition_path: None,
+            runtime_names: vec![artboard_name.clone()],
+            scene_paths: vec!["/artboard".to_string()],
+        });
+
+        let mut children = Vec::with_capacity(self.spec.visual.nodes.len());
+        let mut component_stack = Vec::new();
+        for (index, node) in self.spec.visual.nodes.iter().enumerate() {
+            let authored_path = format!("$.visual.nodes[{index}]");
+            let authored_id = node.id().to_string();
+            let runtime_segments = vec![self.spec.artboard.id.clone(), authored_id.clone()];
+            let scene_path = format!("/artboard/children/{index}");
+            let child = self
+                .lower_node(
+                    node,
+                    authored_path,
+                    None,
+                    authored_id,
+                    runtime_segments,
+                    scene_path,
+                    &self.spec.parameters,
+                    &mut component_stack,
+                )
+                .map_err(AuthoringError::one)?;
+            children.push(child);
+        }
+
+        let animations = self
+            .lower_raw_fragments(
+                &self.spec.motion.raw_animations,
+                "$.motion.raw_animations",
+                "/artboard/animations",
+            )
+            .map_err(AuthoringError::one)?;
+        let state_machines = self
+            .lower_raw_fragments(
+                &self.spec.behavior.raw_state_machines,
+                "$.behavior.raw_state_machines",
+                "/artboard/state_machines",
+            )
+            .map_err(AuthoringError::one)?;
+
+        let mut artboard = json!({
+            "name": artboard_name,
+            "width": width,
+            "height": height,
+            "children": children
+        });
+        if let Some(object) = artboard.as_object_mut() {
+            if !animations.is_empty() {
+                object.insert("animations".to_string(), Value::Array(animations));
+            }
+            if !state_machines.is_empty() {
+                object.insert(
+                    "state_machines".to_string(),
+                    Value::Array(state_machines),
+                );
+            }
+        }
+        let scene = json!({
+            "scene_format_version": 1,
+            "artboard": artboard
+        });
+
+        let scene_spec = serde_json::from_value::<SceneSpec>(scene.clone()).map_err(|error| {
+            AuthoringError::one(AuthoringDiagnostic::new(
+                "$.lowered_scene",
+                "invalid_lowered_scene",
+                error.to_string(),
+            ))
+        })?;
+        build_scene(&scene_spec, None).map_err(|error| {
+            AuthoringError::one(AuthoringDiagnostic::new(
+                "$.lowered_scene",
+                "builder_rejected_scene",
+                error.to_string(),
+            ))
+        })?;
+
+        Ok(LoweredAuthoring {
+            scene,
+            source_map: self.source_map,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn lower_node(
+        &mut self,
+        node: &VisualNode,
+        authored_path: String,
+        definition_path: Option<String>,
+        authored_id: String,
+        runtime_segments: Vec<String>,
+        scene_path: String,
+        scope: &BTreeMap<String, Quantity>,
+        component_stack: &mut Vec<String>,
+    ) -> Result<Value, AuthoringDiagnostic> {
+        match node {
+            VisualNode::Ellipse {
+                width,
+                height,
+                fill,
+                transform,
+                ..
+            } => self.lower_shape(
+                "ellipse",
+                width,
+                height,
+                None,
+                fill,
+                transform,
+                authored_path,
+                definition_path,
+                authored_id,
+                runtime_segments,
+                scene_path,
+                scope,
+            ),
+            VisualNode::Rectangle {
+                width,
+                height,
+                fill,
+                corner_radius,
+                transform,
+                ..
+            } => self.lower_shape(
+                "rectangle",
+                width,
+                height,
+                corner_radius.as_ref(),
+                fill,
+                transform,
+                authored_path,
+                definition_path,
+                authored_id,
+                runtime_segments,
+                scene_path,
+                scope,
+            ),
+            VisualNode::Group {
+                transform,
+                children,
+                ..
+            } => {
+                validate_sibling_ids_result(children, &format!("{authored_path}.children"))?;
+                let transform_values = evaluate_transform(
+                    transform,
+                    &format!("{authored_path}.transform"),
+                    scope,
+                )?;
+                let wrapper_name = runtime_name(&runtime_segments, "group");
+                self.register_runtime_names(
+                    std::slice::from_ref(&wrapper_name),
+                    &format!("{authored_path}.id"),
+                )?;
+                self.source_map.entries.push(SourceMapEntry {
+                    authored_id: authored_id.clone(),
+                    authored_path: authored_path.clone(),
+                    definition_path: definition_path.clone(),
+                    runtime_names: vec![wrapper_name.clone()],
+                    scene_paths: vec![scene_path.clone()],
+                });
+
+                let mut lowered_children = Vec::with_capacity(children.len());
+                for (index, child) in children.iter().enumerate() {
+                    let child_authored_path = format!("{authored_path}.children[{index}]");
+                    let child_definition_path = definition_path
+                        .as_ref()
+                        .map(|path| format!("{path}.children[{index}]"));
+                    let child_authored_id = format!("{authored_id}/{}", child.id());
+                    let mut child_runtime_segments = runtime_segments.clone();
+                    child_runtime_segments.push(child.id().to_string());
+                    let child_scene_path = format!("{scene_path}/children/{index}");
+                    lowered_children.push(self.lower_node(
+                        child,
+                        child_authored_path,
+                        child_definition_path,
+                        child_authored_id,
+                        child_runtime_segments,
+                        child_scene_path,
+                        scope,
+                        component_stack,
+                    )?);
+                }
+
+                Ok(json!({
+                    "type": "node",
+                    "name": wrapper_name,
+                    "x": transform_values.x,
+                    "y": transform_values.y,
+                    "rotation": transform_values.rotation,
+                    "scale_x": transform_values.scale_x,
+                    "scale_y": transform_values.scale_y,
+                    "children": lowered_children
+                }))
+            }
+            VisualNode::Instance {
+                component,
+                overrides,
+                transform,
+                ..
+            } => {
+                let component_ref = *self.components.get(component.as_str()).ok_or_else(|| {
+                    AuthoringDiagnostic::new(
+                        format!("{authored_path}.component"),
+                        "unknown_component",
+                        format!("component '{component}' is not defined"),
+                    )
+                })?;
+                if component_stack.iter().any(|entry| entry == component) {
+                    let mut cycle = component_stack.clone();
+                    cycle.push(component.clone());
+                    return Err(AuthoringDiagnostic::new(
+                        format!("{authored_path}.component"),
+                        "component_cycle",
+                        format!("component cycle detected: {}", cycle.join(" -> ")),
+                    ));
+                }
+                for (name, quantity) in overrides {
+                    if !component_ref.spec.parameters.contains_key(name) {
+                        return Err(AuthoringDiagnostic::new(
+                            format!("{authored_path}.overrides.{name}"),
+                            "unknown_override",
+                            format!(
+                                "component '{}' has no parameter named '{name}'",
+                                component_ref.spec.id
+                            ),
+                        ));
+                    }
+                    if !quantity.value.is_finite() {
+                        return Err(AuthoringDiagnostic::new(
+                            format!("{authored_path}.overrides.{name}.value"),
+                            "non_finite",
+                            "numeric values must be finite",
+                        ));
+                    }
+                }
+
+                let transform_values = evaluate_transform(
+                    transform,
+                    &format!("{authored_path}.transform"),
+                    scope,
+                )?;
+                let wrapper_name = runtime_name(&runtime_segments, "instance");
+                self.register_runtime_names(
+                    std::slice::from_ref(&wrapper_name),
+                    &format!("{authored_path}.id"),
+                )?;
+                self.source_map.entries.push(SourceMapEntry {
+                    authored_id: authored_id.clone(),
+                    authored_path: authored_path.clone(),
+                    definition_path: definition_path.clone(),
+                    runtime_names: vec![wrapper_name.clone()],
+                    scene_paths: vec![scene_path.clone()],
+                });
+
+                let mut component_scope = self.spec.parameters.clone();
+                component_scope.extend(component_ref.spec.parameters.clone());
+                component_scope.extend(overrides.clone());
+                component_stack.push(component.clone());
+                let mut lowered_children = Vec::with_capacity(component_ref.spec.visual.len());
+                for (index, child) in component_ref.spec.visual.iter().enumerate() {
+                    let child_authored_path = format!("{authored_path}.expanded[{index}]");
+                    let child_definition_path = Some(format!(
+                        "$.components[{}].visual[{index}]",
+                        component_ref.index
+                    ));
+                    let child_authored_id = format!("{authored_id}/{}", child.id());
+                    let mut child_runtime_segments = runtime_segments.clone();
+                    child_runtime_segments.push(child.id().to_string());
+                    let child_scene_path = format!("{scene_path}/children/{index}");
+                    match self.lower_node(
+                        child,
+                        child_authored_path,
+                        child_definition_path,
+                        child_authored_id,
+                        child_runtime_segments,
+                        child_scene_path,
+                        &component_scope,
+                        component_stack,
+                    ) {
+                        Ok(child) => lowered_children.push(child),
+                        Err(error) => {
+                            component_stack.pop();
+                            return Err(error);
+                        }
+                    }
+                }
+                component_stack.pop();
+
+                Ok(json!({
+                    "type": "node",
+                    "name": wrapper_name,
+                    "x": transform_values.x,
+                    "y": transform_values.y,
+                    "rotation": transform_values.rotation,
+                    "scale_x": transform_values.scale_x,
+                    "scale_y": transform_values.scale_y,
+                    "children": lowered_children
+                }))
+            }
+            VisualNode::RawSceneObject { object, .. } => {
+                if !object.is_object() {
+                    return Err(AuthoringDiagnostic::new(
+                        format!("{authored_path}.object"),
+                        "invalid_raw_scene_object",
+                        "raw SceneSpec escape must be a JSON object",
+                    ));
+                }
+                let mut runtime_names = Vec::new();
+                let mut scene_paths = Vec::new();
+                collect_named_paths(
+                    object,
+                    &scene_path,
+                    &mut runtime_names,
+                    &mut scene_paths,
+                );
+                self.register_runtime_names(
+                    &runtime_names,
+                    &format!("{authored_path}.object"),
+                )?;
+                self.source_map.entries.push(SourceMapEntry {
+                    authored_id,
+                    authored_path,
+                    definition_path,
+                    runtime_names,
+                    scene_paths: if scene_paths.is_empty() {
+                        vec![scene_path]
+                    } else {
+                        scene_paths
+                    },
+                });
+                Ok(object.clone())
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn lower_shape(
+        &mut self,
+        geometry_type: &str,
+        width_expression: &super::spec::ScalarExpr,
+        height_expression: &super::spec::ScalarExpr,
+        corner_radius_expression: Option<&super::spec::ScalarExpr>,
+        fill: &str,
+        transform: &super::spec::TransformSpec,
+        authored_path: String,
+        definition_path: Option<String>,
+        authored_id: String,
+        runtime_segments: Vec<String>,
+        scene_path: String,
+        scope: &BTreeMap<String, Quantity>,
+    ) -> Result<Value, AuthoringDiagnostic> {
+        let width = evaluate_expression(
+            width_expression,
+            &format!("{authored_path}.width"),
+            scope,
+            Unit::Px,
+        )?;
+        let height = evaluate_expression(
+            height_expression,
+            &format!("{authored_path}.height"),
+            scope,
+            Unit::Px,
+        )?;
+        if width <= 0.0 {
+            return Err(AuthoringDiagnostic::new(
+                format!("{authored_path}.width"),
+                "invalid_dimension",
+                "shape width must be greater than zero",
+            ));
+        }
+        if height <= 0.0 {
+            return Err(AuthoringDiagnostic::new(
+                format!("{authored_path}.height"),
+                "invalid_dimension",
+                "shape height must be greater than zero",
+            ));
+        }
+        let corner_radius = corner_radius_expression
+            .map(|expression| {
+                evaluate_expression(
+                    expression,
+                    &format!("{authored_path}.corner_radius"),
+                    scope,
+                    Unit::Px,
+                )
+            })
+            .transpose()?;
+        if corner_radius.is_some_and(|radius| radius < 0.0) {
+            return Err(AuthoringDiagnostic::new(
+                format!("{authored_path}.corner_radius"),
+                "invalid_dimension",
+                "corner radius must not be negative",
+            ));
+        }
+        let transform_values =
+            evaluate_transform(transform, &format!("{authored_path}.transform"), scope)?;
+
+        let shape_name = runtime_name(&runtime_segments, "shape");
+        let geometry_name = runtime_name(&runtime_segments, "geometry");
+        let fill_name = runtime_name(&runtime_segments, "fill");
+        let color_name = runtime_name(&runtime_segments, "color");
+        let runtime_names = vec![
+            shape_name.clone(),
+            geometry_name.clone(),
+            fill_name.clone(),
+            color_name.clone(),
+        ];
+        self.register_runtime_names(&runtime_names, &format!("{authored_path}.id"))?;
+        let scene_paths = vec![
+            scene_path.clone(),
+            format!("{scene_path}/children/0"),
+            format!("{scene_path}/children/1"),
+            format!("{scene_path}/children/1/children/0"),
+        ];
+        self.source_map.entries.push(SourceMapEntry {
+            authored_id,
+            authored_path,
+            definition_path,
+            runtime_names,
+            scene_paths,
+        });
+
+        let mut geometry = json!({
+            "type": geometry_type,
+            "name": geometry_name,
+            "width": width,
+            "height": height,
+            "origin_x": 0.5,
+            "origin_y": 0.5
+        });
+        if geometry_type == "rectangle" {
+            if let Some(object) = geometry.as_object_mut() {
+                object.insert(
+                    "corner_radius".to_string(),
+                    corner_radius.map_or(Value::Null, Value::from),
+                );
+            }
+        }
+
+        Ok(json!({
+            "type": "shape",
+            "name": shape_name,
+            "x": transform_values.x,
+            "y": transform_values.y,
+            "rotation": transform_values.rotation,
+            "scale_x": transform_values.scale_x,
+            "scale_y": transform_values.scale_y,
+            "children": [
+                geometry,
+                {
+                    "type": "fill",
+                    "name": fill_name,
+                    "children": [
+                        {
+                            "type": "solid_color",
+                            "name": color_name,
+                            "color": fill
+                        }
+                    ]
+                }
+            ]
+        }))
+    }
+
+    fn lower_raw_fragments(
+        &mut self,
+        fragments: &[super::spec::RawSceneFragment],
+        authored_list_path: &str,
+        scene_list_path: &str,
+    ) -> Result<Vec<Value>, AuthoringDiagnostic> {
+        let mut lowered = Vec::with_capacity(fragments.len());
+        for (index, fragment) in fragments.iter().enumerate() {
+            let authored_path = format!("{authored_list_path}[{index}]");
+            if !fragment.value.is_object() {
+                return Err(AuthoringDiagnostic::new(
+                    format!("{authored_path}.value"),
+                    "invalid_raw_scene_fragment",
+                    "raw SceneSpec escape must be a JSON object",
+                ));
+            }
+            let scene_path = format!("{scene_list_path}/{index}");
+            let mut runtime_names = Vec::new();
+            let mut scene_paths = Vec::new();
+            collect_named_paths(
+                &fragment.value,
+                &scene_path,
+                &mut runtime_names,
+                &mut scene_paths,
+            );
+            self.source_map.entries.push(SourceMapEntry {
+                authored_id: fragment.id.clone(),
+                authored_path,
+                definition_path: None,
+                runtime_names,
+                scene_paths: if scene_paths.is_empty() {
+                    vec![scene_path]
+                } else {
+                    scene_paths
+                },
+            });
+            lowered.push(fragment.value.clone());
+        }
+        Ok(lowered)
+    }
+
+    fn register_runtime_names(
+        &mut self,
+        names: &[String],
+        path: &str,
+    ) -> Result<(), AuthoringDiagnostic> {
+        for name in names {
+            if !self.runtime_names.insert(name.clone()) {
+                return Err(AuthoringDiagnostic::new(
+                    path,
+                    "runtime_name_collision",
+                    format!("runtime name '{name}' is generated or declared more than once"),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_id(id: &str, path: &str, diagnostics: &mut Vec<AuthoringDiagnostic>) {
+    if id.trim().is_empty() {
+        diagnostics.push(AuthoringDiagnostic::new(
+            path,
+            "invalid_id",
+            "authored ids must not be empty",
+        ));
+    }
+}
+
+fn validate_parameters(
+    parameters: &BTreeMap<String, Quantity>,
+    path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    for (name, quantity) in parameters {
+        if name.trim().is_empty() {
+            diagnostics.push(AuthoringDiagnostic::new(
+                path,
+                "invalid_parameter",
+                "parameter names must not be empty",
+            ));
+        }
+        if !quantity.value.is_finite() {
+            diagnostics.push(AuthoringDiagnostic::new(
+                format!("{path}.{name}.value"),
+                "non_finite",
+                "numeric values must be finite",
+            ));
+        }
+    }
+}
+
+fn validate_sibling_ids(
+    nodes: &[VisualNode],
+    list_path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    let mut ids = HashSet::new();
+    for (index, node) in nodes.iter().enumerate() {
+        let id_path = format!("{list_path}[{index}].id");
+        validate_id(node.id(), &id_path, diagnostics);
+        if !ids.insert(node.id()) {
+            diagnostics.push(AuthoringDiagnostic::new(
+                id_path,
+                "duplicate_id",
+                format!("authored id '{}' is duplicated among siblings", node.id()),
+            ));
+        }
+    }
+}
+
+fn validate_sibling_ids_result(
+    nodes: &[VisualNode],
+    list_path: &str,
+) -> Result<(), AuthoringDiagnostic> {
+    let mut diagnostics = Vec::new();
+    validate_sibling_ids(nodes, list_path, &mut diagnostics);
+    if let Some(first) = diagnostics.into_iter().next() {
+        Err(first)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_fragment_ids(
+    fragments: &[super::spec::RawSceneFragment],
+    list_path: &str,
+    diagnostics: &mut Vec<AuthoringDiagnostic>,
+) {
+    let mut ids = HashSet::new();
+    for (index, fragment) in fragments.iter().enumerate() {
+        let id_path = format!("{list_path}[{index}].id");
+        validate_id(&fragment.id, &id_path, diagnostics);
+        if !ids.insert(fragment.id.as_str()) {
+            diagnostics.push(AuthoringDiagnostic::new(
+                id_path,
+                "duplicate_id",
+                format!("raw fragment id '{}' is duplicated", fragment.id),
+            ));
+        }
+    }
+}
+
+fn runtime_name(segments: &[String], role: &str) -> String {
+    let mut name = String::from("auth");
+    for segment in segments {
+        name.push_str("__");
+        name.push_str(&encode_name_part(segment));
+    }
+    name.push_str("__");
+    name.push_str(role);
+    name
+}
+
+fn encode_name_part(input: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::new();
+    for byte in input.bytes() {
+        if byte.is_ascii_alphanumeric() {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('_');
+            encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+            encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+    }
+    if encoded.is_empty() {
+        "empty".to_string()
+    } else {
+        encoded
+    }
+}
+
+fn collect_named_paths(
+    value: &Value,
+    scene_path: &str,
+    names: &mut Vec<String>,
+    paths: &mut Vec<String>,
+) {
+    match value {
+        Value::Object(object) => {
+            if let Some(name) = object.get("name").and_then(Value::as_str) {
+                names.push(name.to_string());
+                paths.push(scene_path.to_string());
+            }
+            if let Some(Value::Array(children)) = object.get("children") {
+                for (index, child) in children.iter().enumerate() {
+                    collect_named_paths(
+                        child,
+                        &format!("{scene_path}/children/{index}"),
+                        names,
+                        paths,
+                    );
+                }
+            }
+        }
+        Value::Array(values) => {
+            for (index, child) in values.iter().enumerate() {
+                collect_named_paths(child, &format!("{scene_path}/{index}"), names, paths);
+            }
+        }
+        _ => {}
+    }
+}

--- a/src/authoring/mod.rs
+++ b/src/authoring/mod.rs
@@ -7,6 +7,7 @@ use schemars::schema_for;
 use serde_json::Value;
 
 pub use frontend::{lower_authoring, lower_authoring_json};
+pub use lower::lower_authoring_json as lower_authoring_json_unchecked;
 pub use spec::{
     AUTHORING_FORMAT_VERSION, AuthoringArtboard, AuthoringDiagnostic, AuthoringError,
     AuthoringSourceMap, AuthoringSpec, BehaviorSection, ComponentSpec, LoweredAuthoring,

--- a/src/authoring/mod.rs
+++ b/src/authoring/mod.rs
@@ -101,6 +101,32 @@ mod tests {
     }
 
     #[test]
+    fn degree_normalization_that_underflows_f32_is_rejected() {
+        let mut input = document();
+        input["visual"]["nodes"] = json!([
+            {
+                "kind": "group",
+                "id": "tiny-rotation",
+                "transform": {
+                    "rotation": {
+                        "kind": "literal",
+                        "value": 1.0e-44_f64,
+                        "unit": "degrees"
+                    }
+                },
+                "children": []
+            }
+        ]);
+
+        let error = lower(&input).expect_err("normalized underflow must fail");
+        assert!(has_diagnostic(
+            &error,
+            "numeric_out_of_range",
+            "$.visual.nodes[0].transform.rotation.value"
+        ));
+    }
+
+    #[test]
     fn component_bodies_only_see_declared_component_parameters() {
         let mut input = document();
         input["parameters"] = json!({
@@ -186,5 +212,83 @@ mod tests {
 
         let error = lower(&input).expect_err("ambiguous parameter name must fail");
         assert!(has_diagnostic(&error, "invalid_parameter", "$.parameters"));
+    }
+
+    #[test]
+    fn acyclic_component_depth_is_bounded() {
+        let mut input = document();
+        let components = (0..65)
+            .map(|index| {
+                let visual = if index == 64 {
+                    json!([
+                        {
+                            "kind": "ellipse",
+                            "id": "leaf",
+                            "width": { "kind": "literal", "value": 1.0, "unit": "px" },
+                            "height": { "kind": "literal", "value": 1.0, "unit": "px" },
+                            "fill": "#000000"
+                        }
+                    ])
+                } else {
+                    json!([
+                        {
+                            "kind": "instance",
+                            "id": format!("next-{index}"),
+                            "component": format!("component-{}", index + 1)
+                        }
+                    ])
+                };
+                json!({
+                    "id": format!("component-{index}"),
+                    "visual": visual
+                })
+            })
+            .collect::<Vec<_>>();
+        input["components"] = json!(components);
+        input["visual"]["nodes"] = json!([
+            { "kind": "instance", "id": "root", "component": "component-0" }
+        ]);
+
+        let error = lower(&input).expect_err("deep acyclic expansion must be bounded");
+        assert!(has_diagnostic(
+            &error,
+            "component_expansion_depth_limit",
+            "$.components[63].visual[0].component"
+        ));
+    }
+
+    #[test]
+    fn generated_component_nodes_have_a_total_budget() {
+        let mut input = document();
+        let component_nodes = (0..100)
+            .map(|index| {
+                json!({
+                    "kind": "ellipse",
+                    "id": format!("dot-{index}"),
+                    "width": { "kind": "literal", "value": 1.0, "unit": "px" },
+                    "height": { "kind": "literal", "value": 1.0, "unit": "px" },
+                    "fill": "#000000"
+                })
+            })
+            .collect::<Vec<_>>();
+        input["components"] = json!([
+            { "id": "field", "visual": component_nodes }
+        ]);
+        let instances = (0..101)
+            .map(|index| {
+                json!({
+                    "kind": "instance",
+                    "id": format!("field-{index}"),
+                    "component": "field"
+                })
+            })
+            .collect::<Vec<_>>();
+        input["visual"]["nodes"] = json!(instances);
+
+        let error = lower(&input).expect_err("generated nodes must have a total budget");
+        assert!(error
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "component_expansion_node_limit"));
     }
 }

--- a/src/authoring/mod.rs
+++ b/src/authoring/mod.rs
@@ -174,11 +174,7 @@ mod tests {
         ]);
 
         let error = lower(&input).expect_err("ambiguous authored id must fail");
-        assert!(has_diagnostic(
-            &error,
-            "invalid_id",
-            "$.visual.nodes[0].id"
-        ));
+        assert!(has_diagnostic(&error, "invalid_id", "$.visual.nodes[0].id"));
     }
 
     #[test]

--- a/src/authoring/mod.rs
+++ b/src/authoring/mod.rs
@@ -1,0 +1,35 @@
+mod expression;
+mod lower;
+mod spec;
+
+use schemars::schema_for;
+use serde_json::Value;
+
+pub use lower::{lower_authoring, lower_authoring_json};
+pub use spec::{
+    AUTHORING_FORMAT_VERSION, AuthoringArtboard, AuthoringDiagnostic, AuthoringError,
+    AuthoringSourceMap, AuthoringSpec, BehaviorSection, ComponentSpec, LoweredAuthoring,
+    MotionSection, Quantity, RawSceneFragment, ScalarExpr, SourceMapEntry, TransformSpec, Unit,
+    VisualNode, VisualSection,
+};
+
+pub fn authoring_schema() -> Value {
+    let mut schema = match serde_json::to_value(schema_for!(AuthoringSpec)) {
+        Ok(schema) => schema,
+        Err(_) => Value::Object(serde_json::Map::new()),
+    };
+    if let Some(object) = schema.as_object_mut() {
+        object.insert(
+            "$id".to_string(),
+            Value::String(
+                "https://github.com/George-RD/rive-rs-cli/docs/authoring.schema.v0.json"
+                    .to_string(),
+            ),
+        );
+        object.insert(
+            "title".to_string(),
+            Value::String("rive-cli AuthoringSpec v0".to_string()),
+        );
+    }
+    schema
+}

--- a/src/authoring/mod.rs
+++ b/src/authoring/mod.rs
@@ -286,9 +286,11 @@ mod tests {
         input["visual"]["nodes"] = json!(instances);
 
         let error = lower(&input).expect_err("generated nodes must have a total budget");
-        assert!(error
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.code == "component_expansion_node_limit"));
+        assert!(
+            error
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "component_expansion_node_limit")
+        );
     }
 }

--- a/src/authoring/mod.rs
+++ b/src/authoring/mod.rs
@@ -34,3 +34,161 @@ pub fn authoring_schema() -> Value {
     }
     schema
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::{AuthoringError, authoring_schema, lower_authoring_json};
+
+    fn document() -> Value {
+        json!({
+            "authoring_format_version": 0,
+            "artboard": {
+                "id": "stage",
+                "width": { "value": 320.0, "unit": "px" },
+                "height": { "value": 240.0, "unit": "px" }
+            },
+            "visual": { "nodes": [] },
+            "motion": {},
+            "behavior": {}
+        })
+    }
+
+    fn lower(input: &Value) -> Result<super::LoweredAuthoring, AuthoringError> {
+        lower_authoring_json(&input.to_string())
+    }
+
+    fn has_diagnostic(error: &AuthoringError, code: &str, path: &str) -> bool {
+        error
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == code && diagnostic.path == path)
+    }
+
+    #[test]
+    fn schema_constrains_authoring_version_to_zero() {
+        let schema = authoring_schema();
+        let version = &schema["properties"]["authoring_format_version"];
+
+        assert_eq!(version["minimum"], 0);
+        assert_eq!(version["maximum"], 0);
+    }
+
+    #[test]
+    fn percent_is_not_part_of_the_v0_contract() {
+        let schema = authoring_schema();
+        let schema_text = serde_json::to_string(&schema).expect("serialize authoring schema");
+        assert!(!schema_text.contains("\"percent\""));
+
+        let mut input = document();
+        input["artboard"]["width"]["unit"] = json!("percent");
+        let error = lower(&input).expect_err("unsupported unit must fail at the strict frontend");
+        assert!(has_diagnostic(&error, "invalid_json", "$"));
+    }
+
+    #[test]
+    fn positive_values_that_underflow_f32_are_rejected() {
+        let mut input = document();
+        input["artboard"]["width"]["value"] = json!(1.0e-100_f64);
+
+        let error = lower(&input).expect_err("underflowing values must fail");
+        assert!(has_diagnostic(
+            &error,
+            "numeric_out_of_range",
+            "$.artboard.width.value"
+        ));
+    }
+
+    #[test]
+    fn component_bodies_only_see_declared_component_parameters() {
+        let mut input = document();
+        input["parameters"] = json!({
+            "root_only": { "value": 80.0, "unit": "px" }
+        });
+        input["components"] = json!([
+            {
+                "id": "badge",
+                "visual": [
+                    {
+                        "kind": "rectangle",
+                        "id": "body",
+                        "width": { "kind": "parameter", "name": "root_only" },
+                        "height": { "kind": "literal", "value": 40.0, "unit": "px" },
+                        "fill": "#111827"
+                    }
+                ]
+            }
+        ]);
+        input["visual"]["nodes"] = json!([
+            { "kind": "instance", "id": "root", "component": "badge" }
+        ]);
+
+        let error = lower(&input).expect_err("undeclared component parameter must fail");
+        assert!(has_diagnostic(
+            &error,
+            "unknown_parameter",
+            "$.components[0].visual[0].width.name"
+        ));
+    }
+
+    #[test]
+    fn raw_fragment_runtime_names_share_the_collision_registry() {
+        let mut input = document();
+        input["motion"] = json!({
+            "raw_animations": [
+                {
+                    "id": "first",
+                    "value": {
+                        "name": "duplicate",
+                        "fps": 60,
+                        "duration": 1,
+                        "keyframes": []
+                    }
+                },
+                {
+                    "id": "second",
+                    "value": {
+                        "name": "duplicate",
+                        "fps": 60,
+                        "duration": 1,
+                        "keyframes": []
+                    }
+                }
+            ]
+        });
+
+        let error = lower(&input).expect_err("duplicate runtime name must fail before the builder");
+        assert!(has_diagnostic(
+            &error,
+            "runtime_name_collision",
+            "$.motion.raw_animations[1].value"
+        ));
+    }
+
+    #[test]
+    fn authored_ids_reserve_the_source_map_path_separator() {
+        let mut input = document();
+        input["visual"]["nodes"] = json!([
+            { "kind": "group", "id": "left/disc", "children": [] }
+        ]);
+
+        let error = lower(&input).expect_err("ambiguous authored id must fail");
+        assert!(has_diagnostic(
+            &error,
+            "invalid_id",
+            "$.visual.nodes[0].id"
+        ));
+    }
+
+    #[test]
+    fn parameter_names_cannot_contain_diagnostic_path_metacharacters() {
+        let mut input = document();
+        input["parameters"] = json!({
+            "layout.width": { "value": 80.0, "unit": "px" }
+        });
+
+        let error = lower(&input).expect_err("ambiguous parameter name must fail");
+        assert!(has_diagnostic(&error, "invalid_parameter", "$.parameters"));
+    }
+}

--- a/src/authoring/mod.rs
+++ b/src/authoring/mod.rs
@@ -1,11 +1,12 @@
 mod expression;
+mod frontend;
 mod lower;
 mod spec;
 
 use schemars::schema_for;
 use serde_json::Value;
 
-pub use lower::{lower_authoring, lower_authoring_json};
+pub use frontend::{lower_authoring, lower_authoring_json};
 pub use spec::{
     AUTHORING_FORMAT_VERSION, AuthoringArtboard, AuthoringDiagnostic, AuthoringError,
     AuthoringSourceMap, AuthoringSpec, BehaviorSection, ComponentSpec, LoweredAuthoring,

--- a/src/authoring/mod.rs
+++ b/src/authoring/mod.rs
@@ -7,7 +7,6 @@ use schemars::schema_for;
 use serde_json::Value;
 
 pub use frontend::{lower_authoring, lower_authoring_json};
-pub use lower::lower_authoring_json as lower_authoring_json_unchecked;
 pub use spec::{
     AUTHORING_FORMAT_VERSION, AuthoringArtboard, AuthoringDiagnostic, AuthoringError,
     AuthoringSourceMap, AuthoringSpec, BehaviorSection, ComponentSpec, LoweredAuthoring,

--- a/src/authoring/mod.rs
+++ b/src/authoring/mod.rs
@@ -1,18 +1,39 @@
 mod expression;
 mod frontend;
+mod limits;
 mod lower;
 mod spec;
 
 use schemars::schema_for;
 use serde_json::Value;
 
-pub use frontend::{lower_authoring, lower_authoring_json};
 pub use spec::{
     AUTHORING_FORMAT_VERSION, AuthoringArtboard, AuthoringDiagnostic, AuthoringError,
     AuthoringSourceMap, AuthoringSpec, BehaviorSection, ComponentSpec, LoweredAuthoring,
     MotionSection, Quantity, RawSceneFragment, ScalarExpr, SourceMapEntry, TransformSpec, Unit,
     VisualNode, VisualSection,
 };
+
+pub fn lower_authoring_json(input: &str) -> Result<LoweredAuthoring, AuthoringError> {
+    let spec = serde_json::from_str::<AuthoringSpec>(input).map_err(|error| {
+        AuthoringError::one(AuthoringDiagnostic::new(
+            "$",
+            "invalid_json",
+            format!(
+                "{error} at line {}, column {}",
+                error.line(),
+                error.column()
+            ),
+        ))
+    })?;
+    limits::validate_component_expansion_depth(&spec)?;
+    frontend::lower_authoring_json(input)
+}
+
+pub fn lower_authoring(spec: &AuthoringSpec) -> Result<LoweredAuthoring, AuthoringError> {
+    limits::validate_component_expansion_depth(spec)?;
+    frontend::lower_authoring(spec)
+}
 
 pub fn authoring_schema() -> Value {
     let mut schema = match serde_json::to_value(schema_for!(AuthoringSpec)) {

--- a/src/authoring/spec.rs
+++ b/src/authoring/spec.rs
@@ -1,0 +1,256 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const AUTHORING_FORMAT_VERSION: u32 = 0;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoringSpec {
+    pub authoring_format_version: u32,
+    pub artboard: AuthoringArtboard,
+    #[serde(default)]
+    pub parameters: BTreeMap<String, Quantity>,
+    #[serde(default)]
+    pub components: Vec<ComponentSpec>,
+    pub visual: VisualSection,
+    pub motion: MotionSection,
+    pub behavior: BehaviorSection,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoringArtboard {
+    pub id: String,
+    pub width: Quantity,
+    pub height: Quantity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Quantity {
+    pub value: f64,
+    pub unit: Unit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Unit {
+    Px,
+    Scalar,
+    Percent,
+    Degrees,
+    Radians,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ScalarExpr {
+    Literal {
+        value: f64,
+        unit: Unit,
+    },
+    Parameter {
+        name: String,
+    },
+    Add {
+        left: Box<ScalarExpr>,
+        right: Box<ScalarExpr>,
+    },
+    Subtract {
+        left: Box<ScalarExpr>,
+        right: Box<ScalarExpr>,
+    },
+    Multiply {
+        value: Box<ScalarExpr>,
+        factor: f64,
+    },
+    Divide {
+        value: Box<ScalarExpr>,
+        divisor: f64,
+    },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TransformSpec {
+    #[serde(default)]
+    pub x: Option<ScalarExpr>,
+    #[serde(default)]
+    pub y: Option<ScalarExpr>,
+    #[serde(default)]
+    pub rotation: Option<ScalarExpr>,
+    #[serde(default)]
+    pub scale_x: Option<ScalarExpr>,
+    #[serde(default)]
+    pub scale_y: Option<ScalarExpr>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ComponentSpec {
+    pub id: String,
+    #[serde(default)]
+    pub parameters: BTreeMap<String, Quantity>,
+    pub visual: Vec<VisualNode>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct VisualSection {
+    #[serde(default)]
+    pub nodes: Vec<VisualNode>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum VisualNode {
+    Ellipse {
+        id: String,
+        width: ScalarExpr,
+        height: ScalarExpr,
+        fill: String,
+        #[serde(default)]
+        transform: TransformSpec,
+    },
+    Rectangle {
+        id: String,
+        width: ScalarExpr,
+        height: ScalarExpr,
+        fill: String,
+        #[serde(default)]
+        corner_radius: Option<ScalarExpr>,
+        #[serde(default)]
+        transform: TransformSpec,
+    },
+    Group {
+        id: String,
+        #[serde(default)]
+        transform: TransformSpec,
+        #[serde(default)]
+        children: Vec<VisualNode>,
+    },
+    Instance {
+        id: String,
+        component: String,
+        #[serde(default)]
+        overrides: BTreeMap<String, Quantity>,
+        #[serde(default)]
+        transform: TransformSpec,
+    },
+    RawSceneObject {
+        id: String,
+        object: Value,
+    },
+}
+
+impl VisualNode {
+    pub(crate) fn id(&self) -> &str {
+        match self {
+            Self::Ellipse { id, .. }
+            | Self::Rectangle { id, .. }
+            | Self::Group { id, .. }
+            | Self::Instance { id, .. }
+            | Self::RawSceneObject { id, .. } => id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MotionSection {
+    #[serde(default)]
+    pub raw_animations: Vec<RawSceneFragment>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BehaviorSection {
+    #[serde(default)]
+    pub raw_state_machines: Vec<RawSceneFragment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RawSceneFragment {
+    pub id: String,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct LoweredAuthoring {
+    pub scene: Value,
+    pub source_map: AuthoringSourceMap,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct AuthoringSourceMap {
+    pub entries: Vec<SourceMapEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SourceMapEntry {
+    pub authored_id: String,
+    pub authored_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub definition_path: Option<String>,
+    pub runtime_names: Vec<String>,
+    pub scene_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AuthoringDiagnostic {
+    pub path: String,
+    pub code: String,
+    pub message: String,
+}
+
+impl AuthoringDiagnostic {
+    pub(crate) fn new(
+        path: impl Into<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthoringError {
+    pub diagnostics: Vec<AuthoringDiagnostic>,
+}
+
+impl AuthoringError {
+    pub(crate) fn one(diagnostic: AuthoringDiagnostic) -> Self {
+        Self {
+            diagnostics: vec![diagnostic],
+        }
+    }
+
+    pub(crate) fn many(diagnostics: Vec<AuthoringDiagnostic>) -> Self {
+        Self { diagnostics }
+    }
+}
+
+impl fmt::Display for AuthoringError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(first) = self.diagnostics.first() {
+            write!(
+                formatter,
+                "AuthoringSpec failed at {} [{}]: {}",
+                first.path, first.code, first.message
+            )
+        } else {
+            formatter.write_str("AuthoringSpec failed without a diagnostic")
+        }
+    }
+}
+
+impl std::error::Error for AuthoringError {}

--- a/src/authoring/spec.rs
+++ b/src/authoring/spec.rs
@@ -10,6 +10,7 @@ pub const AUTHORING_FORMAT_VERSION: u32 = 0;
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AuthoringSpec {
+    #[schemars(range(min = 0, max = 0))]
     pub authoring_format_version: u32,
     pub artboard: AuthoringArtboard,
     #[serde(default)]
@@ -41,7 +42,6 @@ pub struct Quantity {
 pub enum Unit {
     Px,
     Scalar,
-    Percent,
     Degrees,
     Radians,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::len_without_is_empty, clippy::new_without_default)]
 
 pub mod ai;
+pub mod authoring;
 pub mod builder;
 pub mod compare;
 pub mod discovery;

--- a/tests/authoring_contract.rs
+++ b/tests/authoring_contract.rs
@@ -136,7 +136,8 @@ const RAW_ESCAPE_SCENE: &str = r##"
 "##;
 
 fn assert_builds(scene: serde_json::Value) {
-    let scene: SceneSpec = serde_json::from_value(scene).expect("lowered SceneSpec must deserialize");
+    let scene: SceneSpec =
+        serde_json::from_value(scene).expect("lowered SceneSpec must deserialize");
     build_scene(&scene, None).expect("lowered SceneSpec must pass the canonical builder");
 }
 
@@ -171,7 +172,12 @@ fn source_map_tracks_generated_runtime_names_and_expansion_paths() {
         .find(|entry| entry.authored_id == "left/disc")
         .expect("expanded component source-map entry");
 
-    assert!(expanded.definition_path.as_deref().is_some_and(|path| path.contains("components[0]")));
+    assert!(
+        expanded
+            .definition_path
+            .as_deref()
+            .is_some_and(|path| path.contains("components[0]"))
+    );
     assert!(expanded.authored_path.contains("visual.nodes[0]"));
     assert_eq!(expanded.runtime_names.len(), 4);
     assert_eq!(expanded.scene_paths.len(), 4);
@@ -209,7 +215,8 @@ fn schema_is_versioned_and_exposes_explicit_authored_graphs() {
 
 #[test]
 fn unknown_component_reports_the_authored_path() {
-    let input = COMPONENT_SCENE.replace("\"component\": \"badge\"", "\"component\": \"missing\"");
+    let input =
+        COMPONENT_SCENE.replace("\"component\": \"badge\"", "\"component\": \"missing\"");
     let error = lower_authoring_json(&input).expect_err("unknown component must fail");
 
     assert!(error.diagnostics.iter().any(|diagnostic| {
@@ -220,7 +227,7 @@ fn unknown_component_reports_the_authored_path() {
 
 #[test]
 fn incompatible_expression_units_report_the_operand_path() {
-    let input = r#"
+    let input = r##"
     {
       "authoring_format_version": 0,
       "artboard": {
@@ -246,7 +253,7 @@ fn incompatible_expression_units_report_the_operand_path() {
       "motion": {},
       "behavior": {}
     }
-    "#;
+    "##;
     let error = lower_authoring_json(input).expect_err("unit mismatch must fail");
 
     assert!(error.diagnostics.iter().any(|diagnostic| {
@@ -257,7 +264,7 @@ fn incompatible_expression_units_report_the_operand_path() {
 
 #[test]
 fn component_cycles_report_the_instance_path() {
-    let input = r#"
+    let input = r##"
     {
       "authoring_format_version": 0,
       "artboard": {
@@ -287,7 +294,7 @@ fn component_cycles_report_the_instance_path() {
       "motion": {},
       "behavior": {}
     }
-    "#;
+    "##;
     let error = lower_authoring_json(input).expect_err("component cycle must fail");
 
     assert!(error.diagnostics.iter().any(|diagnostic| {

--- a/tests/authoring_contract.rs
+++ b/tests/authoring_contract.rs
@@ -215,13 +215,11 @@ fn schema_is_versioned_and_exposes_explicit_authored_graphs() {
 
 #[test]
 fn unknown_component_reports_the_authored_path() {
-    let input =
-        COMPONENT_SCENE.replace("\"component\": \"badge\"", "\"component\": \"missing\"");
+    let input = COMPONENT_SCENE.replace("\"component\": \"badge\"", "\"component\": \"missing\"");
     let error = lower_authoring_json(&input).expect_err("unknown component must fail");
 
     assert!(error.diagnostics.iter().any(|diagnostic| {
-        diagnostic.code == "unknown_component"
-            && diagnostic.path == "$.visual.nodes[0].component"
+        diagnostic.code == "unknown_component" && diagnostic.path == "$.visual.nodes[0].component"
     }));
 }
 
@@ -257,8 +255,7 @@ fn incompatible_expression_units_report_the_operand_path() {
     let error = lower_authoring_json(input).expect_err("unit mismatch must fail");
 
     assert!(error.diagnostics.iter().any(|diagnostic| {
-        diagnostic.code == "unit_mismatch"
-            && diagnostic.path == "$.visual.nodes[0].width.right"
+        diagnostic.code == "unit_mismatch" && diagnostic.path == "$.visual.nodes[0].width.right"
     }));
 }
 

--- a/tests/authoring_contract.rs
+++ b/tests/authoring_contract.rs
@@ -114,7 +114,7 @@ const RAW_ESCAPE_SCENE: &str = r##"
         "id": "pulse-motion",
         "value": {
           "name": "pulse",
-          "fps": 60.0,
+          "fps": 60,
           "duration": 60,
           "keyframes": [
             {

--- a/tests/authoring_contract.rs
+++ b/tests/authoring_contract.rs
@@ -1,0 +1,311 @@
+use std::collections::HashSet;
+
+use rive_cli::authoring::{authoring_schema, lower_authoring_json};
+use rive_cli::builder::{SceneSpec, build_scene};
+
+const COMPONENT_SCENE: &str = r##"
+{
+  "authoring_format_version": 0,
+  "artboard": {
+    "id": "main-stage",
+    "width": { "value": 320.0, "unit": "px" },
+    "height": { "value": 240.0, "unit": "px" }
+  },
+  "parameters": {
+    "gap": { "value": 24.0, "unit": "px" }
+  },
+  "components": [
+    {
+      "id": "badge",
+      "parameters": {
+        "diameter": { "value": 64.0, "unit": "px" }
+      },
+      "visual": [
+        {
+          "kind": "ellipse",
+          "id": "disc",
+          "width": { "kind": "parameter", "name": "diameter" },
+          "height": { "kind": "parameter", "name": "diameter" },
+          "fill": "#246BFD"
+        }
+      ]
+    }
+  ],
+  "visual": {
+    "nodes": [
+      {
+        "kind": "instance",
+        "id": "left",
+        "component": "badge",
+        "overrides": {
+          "diameter": { "value": 72.0, "unit": "px" }
+        },
+        "transform": {
+          "x": { "kind": "literal", "value": 80.0, "unit": "px" },
+          "y": { "kind": "literal", "value": 120.0, "unit": "px" }
+        }
+      },
+      {
+        "kind": "instance",
+        "id": "right",
+        "component": "badge",
+        "transform": {
+          "x": {
+            "kind": "add",
+            "left": { "kind": "literal", "value": 200.0, "unit": "px" },
+            "right": { "kind": "parameter", "name": "gap" }
+          },
+          "y": { "kind": "literal", "value": 120.0, "unit": "px" }
+        }
+      }
+    ]
+  },
+  "motion": {},
+  "behavior": {}
+}
+"##;
+
+const RAW_ESCAPE_SCENE: &str = r##"
+{
+  "authoring_format_version": 0,
+  "artboard": {
+    "id": "raw-stage",
+    "width": { "value": 240.0, "unit": "px" },
+    "height": { "value": 240.0, "unit": "px" }
+  },
+  "visual": {
+    "nodes": [
+      {
+        "kind": "raw_scene_object",
+        "id": "raw-ball",
+        "object": {
+          "type": "shape",
+          "name": "RawBall",
+          "x": 120.0,
+          "y": 120.0,
+          "children": [
+            {
+              "type": "ellipse",
+              "name": "RawBallGeometry",
+              "width": 80.0,
+              "height": 80.0,
+              "origin_x": 0.5,
+              "origin_y": 0.5
+            },
+            {
+              "type": "fill",
+              "name": "RawBallFill",
+              "children": [
+                {
+                  "type": "solid_color",
+                  "name": "RawBallColor",
+                  "color": "#EF4444"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "motion": {
+    "raw_animations": [
+      {
+        "id": "pulse-motion",
+        "value": {
+          "name": "pulse",
+          "fps": 60.0,
+          "duration": 60,
+          "keyframes": [
+            {
+              "object": "RawBallGeometry",
+              "property": "width",
+              "frames": [
+                { "frame": 0, "value": 80.0 },
+                { "frame": 30, "value": 120.0 },
+                { "frame": 59, "value": 80.0 }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "behavior": {}
+}
+"##;
+
+fn assert_builds(scene: serde_json::Value) {
+    let scene: SceneSpec = serde_json::from_value(scene).expect("lowered SceneSpec must deserialize");
+    build_scene(&scene, None).expect("lowered SceneSpec must pass the canonical builder");
+}
+
+#[test]
+fn component_scene_lowers_deterministically_and_builds() {
+    let first = lower_authoring_json(COMPONENT_SCENE).expect("first lowering");
+    let second = lower_authoring_json(COMPONENT_SCENE).expect("second lowering");
+
+    assert_eq!(first.scene, second.scene);
+    assert_eq!(first.source_map, second.source_map);
+    assert_builds(first.scene);
+}
+
+#[test]
+fn raw_escape_scene_lowers_deterministically_and_builds() {
+    let first = lower_authoring_json(RAW_ESCAPE_SCENE).expect("first lowering");
+    let second = lower_authoring_json(RAW_ESCAPE_SCENE).expect("second lowering");
+
+    assert_eq!(first.scene, second.scene);
+    assert_eq!(first.source_map, second.source_map);
+    assert_eq!(first.scene["artboard"]["animations"][0]["name"], "pulse");
+    assert_builds(first.scene);
+}
+
+#[test]
+fn source_map_tracks_generated_runtime_names_and_expansion_paths() {
+    let lowered = lower_authoring_json(COMPONENT_SCENE).expect("lowering");
+    let expanded = lowered
+        .source_map
+        .entries
+        .iter()
+        .find(|entry| entry.authored_id == "left/disc")
+        .expect("expanded component source-map entry");
+
+    assert!(expanded.definition_path.as_deref().is_some_and(|path| path.contains("components[0]")));
+    assert!(expanded.authored_path.contains("visual.nodes[0]"));
+    assert_eq!(expanded.runtime_names.len(), 4);
+    assert_eq!(expanded.scene_paths.len(), 4);
+
+    let names = lowered
+        .source_map
+        .entries
+        .iter()
+        .flat_map(|entry| entry.runtime_names.iter())
+        .collect::<Vec<_>>();
+    let unique = names.iter().copied().collect::<HashSet<_>>();
+    assert_eq!(names.len(), unique.len());
+}
+
+#[test]
+fn schema_is_versioned_and_exposes_explicit_authored_graphs() {
+    let schema = authoring_schema();
+    assert_eq!(
+        schema["$id"],
+        "https://github.com/George-RD/rive-rs-cli/docs/authoring.schema.v0.json"
+    );
+    assert_eq!(schema["title"], "rive-cli AuthoringSpec v0");
+
+    let text = serde_json::to_string(&schema).expect("serialize schema");
+    for required in [
+        "authoring_format_version",
+        "visual",
+        "motion",
+        "behavior",
+        "additionalProperties",
+    ] {
+        assert!(text.contains(required), "schema is missing {required}");
+    }
+}
+
+#[test]
+fn unknown_component_reports_the_authored_path() {
+    let input = COMPONENT_SCENE.replace("\"component\": \"badge\"", "\"component\": \"missing\"");
+    let error = lower_authoring_json(&input).expect_err("unknown component must fail");
+
+    assert!(error.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "unknown_component"
+            && diagnostic.path == "$.visual.nodes[0].component"
+    }));
+}
+
+#[test]
+fn incompatible_expression_units_report_the_operand_path() {
+    let input = r#"
+    {
+      "authoring_format_version": 0,
+      "artboard": {
+        "id": "units",
+        "width": { "value": 100.0, "unit": "px" },
+        "height": { "value": 100.0, "unit": "px" }
+      },
+      "visual": {
+        "nodes": [
+          {
+            "kind": "rectangle",
+            "id": "box",
+            "width": {
+              "kind": "add",
+              "left": { "kind": "literal", "value": 40.0, "unit": "px" },
+              "right": { "kind": "literal", "value": 2.0, "unit": "scalar" }
+            },
+            "height": { "kind": "literal", "value": 40.0, "unit": "px" },
+            "fill": "#111827"
+          }
+        ]
+      },
+      "motion": {},
+      "behavior": {}
+    }
+    "#;
+    let error = lower_authoring_json(input).expect_err("unit mismatch must fail");
+
+    assert!(error.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "unit_mismatch"
+            && diagnostic.path == "$.visual.nodes[0].width.right"
+    }));
+}
+
+#[test]
+fn component_cycles_report_the_instance_path() {
+    let input = r#"
+    {
+      "authoring_format_version": 0,
+      "artboard": {
+        "id": "cycle",
+        "width": { "value": 100.0, "unit": "px" },
+        "height": { "value": 100.0, "unit": "px" }
+      },
+      "components": [
+        {
+          "id": "a",
+          "visual": [
+            { "kind": "instance", "id": "to-b", "component": "b" }
+          ]
+        },
+        {
+          "id": "b",
+          "visual": [
+            { "kind": "instance", "id": "to-a", "component": "a" }
+          ]
+        }
+      ],
+      "visual": {
+        "nodes": [
+          { "kind": "instance", "id": "root", "component": "a" }
+        ]
+      },
+      "motion": {},
+      "behavior": {}
+    }
+    "#;
+    let error = lower_authoring_json(input).expect_err("component cycle must fail");
+
+    assert!(error.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "component_cycle" && diagnostic.path.contains("component")
+    }));
+}
+
+#[test]
+fn unknown_fields_are_rejected_by_the_strict_frontend() {
+    let input = COMPONENT_SCENE.replace(
+        "\"authoring_format_version\": 0,",
+        "\"authoring_format_version\": 0, \"surprise\": true,",
+    );
+    let error = lower_authoring_json(&input).expect_err("unknown field must fail");
+
+    assert!(error.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "invalid_json"
+            && diagnostic.path == "$"
+            && diagnostic.message.contains("unknown field")
+    }));
+}

--- a/tests/authoring_examples.rs
+++ b/tests/authoring_examples.rs
@@ -1,0 +1,32 @@
+use rive_cli::authoring::lower_authoring_json;
+use rive_cli::builder::{SceneSpec, build_scene};
+
+const COMPONENT_BADGES: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/authoring/component-badges.v0.json"
+));
+const RAW_PULSE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/authoring/raw-pulse.v0.json"
+));
+
+fn assert_deterministic_and_buildable(input: &str) {
+    let first = lower_authoring_json(input).expect("first lowering must succeed");
+    let second = lower_authoring_json(input).expect("second lowering must succeed");
+    assert_eq!(first.scene, second.scene);
+    assert_eq!(first.source_map, second.source_map);
+
+    let scene: SceneSpec =
+        serde_json::from_value(first.scene).expect("lowered scene must deserialize");
+    build_scene(&scene, None).expect("lowered scene must pass the canonical builder");
+}
+
+#[test]
+fn component_badges_example_is_deterministic_and_buildable() {
+    assert_deterministic_and_buildable(COMPONENT_BADGES);
+}
+
+#[test]
+fn raw_pulse_example_is_deterministic_and_buildable() {
+    assert_deterministic_and_buildable(RAW_PULSE);
+}

--- a/tests/authoring_validation_contract.rs
+++ b/tests/authoring_validation_contract.rs
@@ -18,8 +18,7 @@ fn out_of_range_authoring_number_reports_the_authored_value_path() {
 
     let error = lower_authoring_json(input).expect_err("f32 overflow must fail before lowering");
     assert!(error.diagnostics.iter().any(|diagnostic| {
-        diagnostic.code == "numeric_out_of_range"
-            && diagnostic.path == "$.artboard.width.value"
+        diagnostic.code == "numeric_out_of_range" && diagnostic.path == "$.artboard.width.value"
     }));
 }
 
@@ -121,8 +120,7 @@ fn unused_raw_component_objects_pass_canonical_scene_validation() {
 
     let error = lower_authoring_json(input).expect_err("unused raw object must be validated");
     assert!(error.diagnostics.iter().any(|diagnostic| {
-        diagnostic.code == "invalid_component_scene"
-            && diagnostic.path == "$.components[0].visual"
+        diagnostic.code == "invalid_component_scene" && diagnostic.path == "$.components[0].visual"
     }));
 }
 

--- a/tests/authoring_validation_contract.rs
+++ b/tests/authoring_validation_contract.rs
@@ -1,0 +1,172 @@
+use rive_cli::authoring::lower_authoring_json;
+
+#[test]
+fn out_of_range_authoring_number_reports_the_authored_value_path() {
+    let input = r#"
+    {
+      "authoring_format_version": 0,
+      "artboard": {
+        "id": "overflow",
+        "width": { "value": 1e100, "unit": "px" },
+        "height": { "value": 100.0, "unit": "px" }
+      },
+      "visual": { "nodes": [] },
+      "motion": {},
+      "behavior": {}
+    }
+    "#;
+
+    let error = lower_authoring_json(input).expect_err("f32 overflow must fail before lowering");
+    assert!(error.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "numeric_out_of_range"
+            && diagnostic.path == "$.artboard.width.value"
+    }));
+}
+
+#[test]
+fn unused_component_references_are_validated() {
+    let input = r#"
+    {
+      "authoring_format_version": 0,
+      "artboard": {
+        "id": "unused-reference",
+        "width": { "value": 100.0, "unit": "px" },
+        "height": { "value": 100.0, "unit": "px" }
+      },
+      "components": [
+        {
+          "id": "unused",
+          "visual": [
+            { "kind": "instance", "id": "broken", "component": "missing" }
+          ]
+        }
+      ],
+      "visual": { "nodes": [] },
+      "motion": {},
+      "behavior": {}
+    }
+    "#;
+
+    let error = lower_authoring_json(input).expect_err("unused component must be validated");
+    assert!(error.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "unknown_component"
+            && diagnostic.path == "$.components[0].visual[0].component"
+    }));
+}
+
+#[test]
+fn unused_component_cycles_are_validated() {
+    let input = r#"
+    {
+      "authoring_format_version": 0,
+      "artboard": {
+        "id": "unused-cycle",
+        "width": { "value": 100.0, "unit": "px" },
+        "height": { "value": 100.0, "unit": "px" }
+      },
+      "components": [
+        {
+          "id": "a",
+          "visual": [
+            { "kind": "instance", "id": "to-b", "component": "b" }
+          ]
+        },
+        {
+          "id": "b",
+          "visual": [
+            { "kind": "instance", "id": "to-a", "component": "a" }
+          ]
+        }
+      ],
+      "visual": { "nodes": [] },
+      "motion": {},
+      "behavior": {}
+    }
+    "#;
+
+    let error = lower_authoring_json(input).expect_err("unused cycle must be validated");
+    assert!(error.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "component_cycle"
+            && diagnostic.path == "$.components[1].visual[0].component"
+    }));
+}
+
+#[test]
+fn unused_raw_component_objects_pass_canonical_scene_validation() {
+    let input = r#"
+    {
+      "authoring_format_version": 0,
+      "artboard": {
+        "id": "unused-raw",
+        "width": { "value": 100.0, "unit": "px" },
+        "height": { "value": 100.0, "unit": "px" }
+      },
+      "components": [
+        {
+          "id": "unused",
+          "visual": [
+            {
+              "kind": "raw_scene_object",
+              "id": "bad-raw",
+              "object": { "type": "not_a_scene_object", "name": "BadRaw" }
+            }
+          ]
+        }
+      ],
+      "visual": { "nodes": [] },
+      "motion": {},
+      "behavior": {}
+    }
+    "#;
+
+    let error = lower_authoring_json(input).expect_err("unused raw object must be validated");
+    assert!(error.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "invalid_component_scene"
+            && diagnostic.path == "$.components[0].visual"
+    }));
+}
+
+#[test]
+fn instantiated_component_errors_report_the_definition_path() {
+    let input = r##"
+    {
+      "authoring_format_version": 0,
+      "artboard": {
+        "id": "definition-path",
+        "width": { "value": 100.0, "unit": "px" },
+        "height": { "value": 100.0, "unit": "px" }
+      },
+      "components": [
+        {
+          "id": "broken-box",
+          "visual": [
+            {
+              "kind": "rectangle",
+              "id": "box",
+              "width": {
+                "kind": "add",
+                "left": { "kind": "literal", "value": 40.0, "unit": "px" },
+                "right": { "kind": "literal", "value": 2.0, "unit": "scalar" }
+              },
+              "height": { "kind": "literal", "value": 40.0, "unit": "px" },
+              "fill": "#111827"
+            }
+          ]
+        }
+      ],
+      "visual": {
+        "nodes": [
+          { "kind": "instance", "id": "broken", "component": "broken-box" }
+        ]
+      },
+      "motion": {},
+      "behavior": {}
+    }
+    "##;
+
+    let error = lower_authoring_json(input).expect_err("invalid component expression must fail");
+    assert!(error.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "unit_mismatch"
+            && diagnostic.path == "$.components[0].visual[0].width.right"
+    }));
+}


### PR DESCRIPTION
## Scope

Complete the next P0 roadmap boundary: a strict, versioned AI-facing `AuthoringSpec v0` that lowers deterministically into canonical `SceneSpec v1` without creating another encoder path.

## Delivered

- Added the public `authoring_schema()`, `lower_authoring()`, and `lower_authoring_json()` boundary.
- Added explicit visual, component, motion, and behavior graphs with typed units and data-only expressions.
- Added deterministic component expansion, runtime naming, source maps, raw canonical escape hatches, and authored-path diagnostics.
- Added two deterministic, builder-valid examples plus contract and validation suites.
- Added iterative component-expansion preflight with a maximum active depth of 64 and a 10,000 generated-node budget.
- Added documentation, Cairn architecture wiring, and roadmap status updates.
- Marked **AuthoringSpec v0 and lowering boundary** complete; **Visual/component compiler slice** is now the next roadmap item.

## TDD evidence

### Cycle 1 — freeze and harden the v0 contract

**RED**

- Commit: [`aba4f3d`](https://github.com/George-RD/rive-rs-cli/commit/aba4f3d322b8acc2fef28a864e3f8c3caa336fa0)
- CI: [run 30472821209](https://github.com/George-RD/rive-rs-cli/actions/runs/30472821209)
- Formatting, Clippy, and browser contracts passed.
- Rust recorded **592 passed / 7 failed**, with the failures defining:
  - singleton v0 schema version;
  - unsupported `percent` removal;
  - `f64` values that underflow during `f32` lowering;
  - component parameter-scope isolation;
  - raw-fragment runtime-name collisions;
  - source-map separator ambiguity;
  - diagnostic-path-safe parameter names.

**GREEN**

- Commit: [`f1cdda7`](https://github.com/George-RD/rive-rs-cli/commit/f1cdda73846a7f302555ae701dfa8d8dfa693bde)
- CI: [run 30473607045](https://github.com/George-RD/rive-rs-cli/actions/runs/30473607045)
- All seven jobs passed; Rust recorded **809 passed / 0 failed**.

### Cycle 2 — bound normalization and component expansion

**RED A: conversion and depth**

- Commit: [`10fabeb`](https://github.com/George-RD/rive-rs-cli/commit/10fabeb485a3de61d1ddb8fb0b75cf36fe52be7a)
- CI: [run 30474331980](https://github.com/George-RD/rive-rs-cli/actions/runs/30474331980)
- Formatting, Clippy, and browser contracts passed.
- The degree-normalization contract failed and the 65-component acyclic-chain contract reproduced an actual Rust stack-overflow abort.

**RED B: isolated breadth budget**

- Commit: [`4f3a641`](https://github.com/George-RD/rive-rs-cli/commit/4f3a6417a0e27a818f23e2fe1435e514e4c58136)
- CI: [run 30474944147](https://github.com/George-RD/rive-rs-cli/actions/runs/30474944147)
- Post-conversion validation and the iterative depth guard passed.
- Rust recorded **601 passed / 1 failed**; only `generated_component_nodes_have_a_total_budget` remained RED.

**FINAL GREEN**

- Head: [`bb8617f`](https://github.com/George-RD/rive-rs-cli/commit/bb8617fe026c970f2f0e03f179273854de7b6f1e)
- CI: [run 30475404072](https://github.com/George-RD/rive-rs-cli/actions/runs/30475404072)
- **All seven CI jobs passed**:
  - formatting and Clippy;
  - Rust tests;
  - browser contracts;
  - Cairn 0.9 architecture validation;
  - official-runtime evaluation evidence;
  - demo and site validation;
  - Playwright browser and visual regression.
- Rust evidence: **812 passed / 0 failed** across 602 library tests, 8 authoring contracts, 2 authoring examples, 5 authoring validation contracts, 191 CLI E2E tests, and 4 eval contracts.

## Review hardening

Review findings were verified against the current implementation, covered by regression tests, and resolved:

- reject `f32` overflow, direct underflow, and underflow introduced by degree-to-radian conversion;
- validate unused component graphs and report real definition paths;
- prevent document parameters leaking into component bodies;
- enforce one runtime-name registry across generated and raw values;
- constrain schema version to exactly `0` and remove unsupported `percent`;
- reserve `/` in authored IDs and restrict parameter names to unambiguous characters;
- preflight recursive expansion iteratively, capping active depth at 64 and generated nodes at 10,000.

The strict frontend remains the public boundary; lowering still terminates in the existing canonical builder and encoder path.