### PR TITLE
Harden mirror lowering with inline unit tests

### DIFF
--- a/meta/todos/todo.visual-authoring-compiler.md
+++ b/meta/todos/todo.visual-authoring-compiler.md
@@ -80,8 +80,10 @@ components, instances, and bounded patterns into explicit SceneSpec objects.
 - Grid, radial, and mirror placement lowering now share explicit position, rotation,
   and scale metadata instead of duplicating pattern-specific wrapper construction.
 - PR #151 hardens the merged mirror slice after delayed review by extracting the
-  axis-to-placement mapping into one documented pure helper and pinning it with an inline
+  axis-to-placement mapping into one pure helper and pinning it with an inline
   `#[cfg(test)]` unit contract while retaining the public end-to-end contract suite.
+- Review remediation keeps Rust source comment-free under the repository compliance
+  policy; durable explanation remains in this Cairn work item and the public contracts.
 - Remaining work includes distribute/along-path patterns, constraints, and a complex
   static showcase without raw escapes.
 

--- a/meta/todos/todo.visual-authoring-compiler.md
+++ b/meta/todos/todo.visual-authoring-compiler.md
@@ -79,6 +79,9 @@ components, instances, and bounded patterns into explicit SceneSpec objects.
   10,000-node expansion budget.
 - Grid, radial, and mirror placement lowering now share explicit position, rotation,
   and scale metadata instead of duplicating pattern-specific wrapper construction.
+- PR #151 hardens the merged mirror slice after delayed review by extracting the
+  axis-to-placement mapping into one documented pure helper and pinning it with an inline
+  `#[cfg(test)]` unit contract while retaining the public end-to-end contract suite.
 - Remaining work includes distribute/along-path patterns, constraints, and a complex
   static showcase without raw escapes.
 

--- a/src/authoring/lower/pattern.rs
+++ b/src/authoring/lower/pattern.rs
@@ -1,5 +1,3 @@
-//! Deterministic lowering for bounded visual patterns.
-
 use serde_json::{Value, json};
 
 use super::super::deterministic_math::sin_cos;
@@ -10,7 +8,6 @@ use super::super::visual::{
 };
 use super::{Lowerer, NodeContext, runtime_name};
 
-/// Fully resolved transform data for one generated pattern cell.
 struct PatternPlacement {
     segment: String,
     x: f64,
@@ -21,7 +18,6 @@ struct PatternPlacement {
 }
 
 impl PatternPlacement {
-    /// Creates a translated or rotated placement with identity scale.
     fn positioned(segment: impl Into<String>, x: f64, y: f64, rotation: f64) -> Self {
         Self {
             segment: segment.into(),
@@ -33,7 +29,6 @@ impl PatternPlacement {
         }
     }
 
-    /// Creates an origin-centred placement with explicit reflection scales.
     fn reflected(segment: impl Into<String>, scale_x: f64, scale_y: f64) -> Self {
         Self {
             segment: segment.into(),
@@ -46,7 +41,6 @@ impl PatternPlacement {
     }
 }
 
-/// Returns the two stable cells generated for a semantic mirror axis.
 fn mirror_placements(axis: MirrorAxis) -> [PatternPlacement; 2] {
     let (scale_x, scale_y) = match axis {
         MirrorAxis::Vertical => (-1.0, 1.0),
@@ -59,7 +53,6 @@ fn mirror_placements(axis: MirrorAxis) -> [PatternPlacement; 2] {
 }
 
 impl<'a> Lowerer<'a> {
-    /// Dispatches a typed pattern through its deterministic lowering path.
     pub(super) fn lower_pattern(
         &mut self,
         pattern: PatternNodeRef<'_>,
@@ -73,7 +66,6 @@ impl<'a> Lowerer<'a> {
         }
     }
 
-    /// Resolves row-major grid coordinates before shared repeated-pattern lowering.
     fn lower_grid(
         &mut self,
         grid: GridNodeRef<'_>,
@@ -127,7 +119,6 @@ impl<'a> Lowerer<'a> {
         )
     }
 
-    /// Resolves deterministic polar coordinates before shared repeated-pattern lowering.
     fn lower_radial(
         &mut self,
         radial: RadialNodeRef<'_>,
@@ -195,7 +186,6 @@ impl<'a> Lowerer<'a> {
         )
     }
 
-    /// Lowers the two placements defined by a semantic mirror axis.
     fn lower_mirror(
         &mut self,
         mirror: MirrorNodeRef<'_>,
@@ -219,7 +209,6 @@ impl<'a> Lowerer<'a> {
         )
     }
 
-    /// Expands resolved cells while preserving names, source maps, and component context.
     fn lower_repeated_pattern(
         &mut self,
         role: &str,

--- a/src/authoring/lower/pattern.rs
+++ b/src/authoring/lower/pattern.rs
@@ -1,3 +1,5 @@
+//! Deterministic lowering for bounded visual patterns.
+
 use serde_json::{Value, json};
 
 use super::super::deterministic_math::sin_cos;
@@ -8,6 +10,7 @@ use super::super::visual::{
 };
 use super::{Lowerer, NodeContext, runtime_name};
 
+/// Fully resolved transform data for one generated pattern cell.
 struct PatternPlacement {
     segment: String,
     x: f64,
@@ -18,6 +21,7 @@ struct PatternPlacement {
 }
 
 impl PatternPlacement {
+    /// Creates a translated or rotated placement with identity scale.
     fn positioned(segment: impl Into<String>, x: f64, y: f64, rotation: f64) -> Self {
         Self {
             segment: segment.into(),
@@ -29,6 +33,7 @@ impl PatternPlacement {
         }
     }
 
+    /// Creates an origin-centred placement with explicit reflection scales.
     fn reflected(segment: impl Into<String>, scale_x: f64, scale_y: f64) -> Self {
         Self {
             segment: segment.into(),
@@ -41,7 +46,20 @@ impl PatternPlacement {
     }
 }
 
+/// Returns the two stable cells generated for a semantic mirror axis.
+fn mirror_placements(axis: MirrorAxis) -> [PatternPlacement; 2] {
+    let (scale_x, scale_y) = match axis {
+        MirrorAxis::Vertical => (-1.0, 1.0),
+        MirrorAxis::Horizontal => (1.0, -1.0),
+    };
+    [
+        PatternPlacement::positioned("original", 0.0, 0.0, 0.0),
+        PatternPlacement::reflected("mirrored", scale_x, scale_y),
+    ]
+}
+
 impl<'a> Lowerer<'a> {
+    /// Dispatches a typed pattern through its deterministic lowering path.
     pub(super) fn lower_pattern(
         &mut self,
         pattern: PatternNodeRef<'_>,
@@ -55,6 +73,7 @@ impl<'a> Lowerer<'a> {
         }
     }
 
+    /// Resolves row-major grid coordinates before shared repeated-pattern lowering.
     fn lower_grid(
         &mut self,
         grid: GridNodeRef<'_>,
@@ -108,6 +127,7 @@ impl<'a> Lowerer<'a> {
         )
     }
 
+    /// Resolves deterministic polar coordinates before shared repeated-pattern lowering.
     fn lower_radial(
         &mut self,
         radial: RadialNodeRef<'_>,
@@ -175,6 +195,7 @@ impl<'a> Lowerer<'a> {
         )
     }
 
+    /// Lowers the two placements defined by a semantic mirror axis.
     fn lower_mirror(
         &mut self,
         mirror: MirrorNodeRef<'_>,
@@ -186,14 +207,7 @@ impl<'a> Lowerer<'a> {
             item,
             transform,
         } = mirror;
-        let (scale_x, scale_y) = match axis {
-            MirrorAxis::Vertical => (-1.0, 1.0),
-            MirrorAxis::Horizontal => (1.0, -1.0),
-        };
-        let placements = vec![
-            PatternPlacement::positioned("original", 0.0, 0.0, 0.0),
-            PatternPlacement::reflected("mirrored", scale_x, scale_y),
-        ];
+        let placements = Vec::from(mirror_placements(axis));
 
         self.lower_repeated_pattern(
             "mirror",
@@ -205,6 +219,7 @@ impl<'a> Lowerer<'a> {
         )
     }
 
+    /// Expands resolved cells while preserving names, source maps, and component context.
     fn lower_repeated_pattern(
         &mut self,
         role: &str,

--- a/src/authoring/lower/pattern.rs
+++ b/src/authoring/lower/pattern.rs
@@ -294,3 +294,30 @@ impl<'a> Lowerer<'a> {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{MirrorAxis, mirror_placements};
+
+    #[test]
+    fn mirror_placements_reflect_across_the_requested_axis() {
+        let vertical = mirror_placements(MirrorAxis::Vertical);
+        assert_eq!(vertical[0].segment, "original");
+        assert_eq!(vertical[0].x, 0.0);
+        assert_eq!(vertical[0].y, 0.0);
+        assert_eq!(vertical[0].rotation, 0.0);
+        assert_eq!(vertical[0].scale_x, 1.0);
+        assert_eq!(vertical[0].scale_y, 1.0);
+        assert_eq!(vertical[1].segment, "mirrored");
+        assert_eq!(vertical[1].scale_x, -1.0);
+        assert_eq!(vertical[1].scale_y, 1.0);
+
+        let horizontal = mirror_placements(MirrorAxis::Horizontal);
+        assert_eq!(horizontal[0].segment, "original");
+        assert_eq!(horizontal[0].scale_x, 1.0);
+        assert_eq!(horizontal[0].scale_y, 1.0);
+        assert_eq!(horizontal[1].segment, "mirrored");
+        assert_eq!(horizontal[1].scale_x, 1.0);
+        assert_eq!(horizontal[1].scale_y, -1.0);
+    }
+}


### PR DESCRIPTION
## Scope

Follow up the delayed review finding on merged PR #150 by adding an inline unit contract in `src/authoring/lower/pattern.rs`, while retaining the public integration suite for end-to-end schema, source-map, builder, and expansion behavior.

## Changes

- extract the axis-to-placement mapping from `lower_mirror` into the pure `mirror_placements` helper;
- pin both horizontal and vertical placement semantics in an inline `#[cfg(test)]` unit contract;
- retain the four public mirror integration contracts unchanged;
- keep Rust source comment-free under repository compliance rule 37558;
- record the review remediation and rationale in the active Cairn work item.

## TDD evidence

### RED

Run `30636889925` on commit `568749b704843d211912863892489d941f34a630` passed rustfmt, then warnings-denied Clippy failed at compilation because the new inline test referenced the intentionally missing `mirror_placements` helper.

### GREEN

Run `30637131611` on commit `7ff48b648813f59da6ba7175380c1bf682afa057` passed:

- `cargo fmt --check`;
- warnings-denied Clippy;
- locked all-feature Rust tests, including 609 library tests, 191 CLI end-to-end tests, the new inline unit test, and the existing four mirror integration contracts;
- shared and visual browser contracts;
- official-runtime evaluation;
- Cairn 0.9.0 scan and lint;
- Playwright regression and visual regression;
- demo validation;
- site validation.

Qodo then identified that the added Rust doc comments violated repository compliance rule 37558. Commit `c03a34f930bc5659feeb7f3f6ee4bebda1d02228` removes those source comments without changing behavior and moves the durable explanation into Cairn. The final clean-state CI run is the merge gate.

Refs #150 and Qodo review comments `5143599940` and `5143805345`.