### PR TITLE
Harden motion lowering after PR #157 review

### DIFF
--- a/meta/contracts/authoring.md
+++ b/meta/contracts/authoring.md
@@ -26,9 +26,16 @@ It must provide:
 The current motion subset supports named transform poses and compact pose tracks
 with authored visual targets, scalar-expression frame timing, `hold` or `linear`
 interpolation, and `oneshot`, `loop`, or `pingpong` loop behavior. Every pose used
-by one track declares the same target/property shape. Tracks lower through the
-canonical builder, retain deterministic runtime names, and map errors and runtime
-objects back to `$.motion.tracks` and `$.motion.poses`. Raw state-machine escapes
+by one track declares the same target/property shape. Frame and duration
+expressions must resolve to non-negative whole numbers; bounded floating-point
+round-off around a whole number is normalized deterministically, while material
+fractional values are rejected. The complete typed-motion document may expand to
+at most 10,000 canonical property-keyframe values, preventing individually valid
+poses and tracks from creating an unbounded Cartesian expansion. Tracks lower
+through the canonical builder, retain deterministic runtime names, and map errors
+and runtime objects back to `$.motion.tracks` and `$.motion.poses`. Visual motion
+targets are indexed once from the authored source map, and failed invariants return
+structured authored diagnostics rather than panicking. Raw state-machine escapes
 may reference generated track runtime names in the same document because final
 canonical validation occurs only after typed animations are present. Shared easing
 definitions, semantic motion helpers, non-transform property tracks, and typed

--- a/meta/todos/todo.motion-authoring-compiler.md
+++ b/meta/todos/todo.motion-authoring-compiler.md
@@ -31,7 +31,7 @@ PR #157 establishes the first cohesive motion-compiler slice:
 - `tests/authoring_motion_contract.rs` covers deterministic lowering, canonical builder acceptance, exact authored-path diagnostics, schema exposure, raw-animation offsets, and behavior-reference integration;
 - the generated `docs/authoring.schema.v0.json` records the public JSON contract.
 
-TDD and review hardening:
+TDD and review hardening for PR #157:
 
 - RED `76a30fe` proved the strict frontend did not yet accept poses or tracks.
 - RED `aaae4dd` proved preliminary lowering could not resolve a generated typed animation from a raw state-machine escape.
@@ -42,7 +42,19 @@ TDD and review hardening:
 - Exact head `eb7216e` passed CI run 694 across formatting, Clippy, Rust, browser contracts, Cairn, official-runtime evidence, demo, site, Playwright, and visual regression.
 - PR #157 merged to `main` as `7034e4f` on 2026-08-03.
 
-The roadmap now tracks incremental typed authoring operations as a separate P3
+The post-merge audit reconciled `ROADMAP.md`, this Cairn todo, open and merged
+pull requests, retained branches, delayed reviews, and exact-head CI. It found no
+new roadmap gap: the review remediation is hardening of this existing P2 todo.
+PR #159 records that follow-up:
+
+- exact-head RED `35a70b0` in CI run `30818628328` proved that aggregate pose/track expansion was unbounded and arithmetic expressions resolving within floating-point noise of a whole frame were rejected;
+- validation now caps the complete typed-motion document at 10,000 generated property-keyframe values before Cartesian lowering;
+- frame and duration expressions normalize only bounded round-off around whole numbers and continue to reject material fractional values;
+- visual motion targets are indexed once instead of rescanning the full source map for every pose target;
+- the checked pose-shape invariant now returns an authored `pose_shape_mismatch` diagnostic rather than using a panic shortcut;
+- exact implementation head `197d4cd` passed rustfmt, Clippy, the complete Rust suite, browser contracts, and Cairn scan/lint in CI run 704 before the durable contract evidence was committed.
+
+The roadmap tracks incremental typed authoring operations as a separate P3
 milestone rather than leaving that AI-skill unblock condition implicit.
 
 ## Remaining

--- a/src/authoring/frontend/motion.rs
+++ b/src/authoring/frontend/motion.rs
@@ -109,7 +109,7 @@ fn resolve_poses(
     spec: &AuthoringSpec,
     source_map: &AuthoringSourceMap,
 ) -> Result<Vec<PoseValues>, AuthoringDiagnostic> {
-    let target_index = index_motion_targets(source_map);
+    let motion_targets = index_motion_targets(source_map);
     let mut poses = Vec::with_capacity(spec.motion.poses.len());
     for (pose_index, pose) in spec.motion.poses.iter().enumerate() {
         let pose_path = format!("$.motion.poses[{pose_index}]");
@@ -117,7 +117,7 @@ fn resolve_poses(
         for (target_index, target) in pose.targets.iter().enumerate() {
             let target_path = format!("{pose_path}.targets[{target_index}]");
             let runtime_name = resolve_target_runtime_name(
-                &target_index,
+                &motion_targets,
                 &target.target,
                 &format!("{target_path}.target"),
             )?;

--- a/src/authoring/frontend/motion.rs
+++ b/src/authoring/frontend/motion.rs
@@ -1,5 +1,6 @@
 mod validation;
 
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 
 use serde_json::json;
@@ -59,8 +60,17 @@ const TRANSFORM_PROPERTIES: [TransformProperty; 5] = [
     TransformProperty::ScaleX,
     TransformProperty::ScaleY,
 ];
+const FRAME_ROUNDING_ULPS: f64 = 8.0;
+const MAX_FRAME_ROUNDING_ERROR: f64 = 1e-9;
 
 type PoseValues = BTreeMap<(String, TransformProperty), f64>;
+type MotionTargetIndex<'a> = HashMap<&'a str, IndexedMotionTarget<'a>>;
+
+#[derive(Clone, Copy)]
+enum IndexedMotionTarget<'a> {
+    Unique(Option<&'a str>),
+    Ambiguous,
+}
 
 struct ResolvedFrame {
     authored_index: usize,
@@ -99,6 +109,7 @@ fn resolve_poses(
     spec: &AuthoringSpec,
     source_map: &AuthoringSourceMap,
 ) -> Result<Vec<PoseValues>, AuthoringDiagnostic> {
+    let target_index = index_motion_targets(source_map);
     let mut poses = Vec::with_capacity(spec.motion.poses.len());
     for (pose_index, pose) in spec.motion.poses.iter().enumerate() {
         let pose_path = format!("$.motion.poses[{pose_index}]");
@@ -106,7 +117,7 @@ fn resolve_poses(
         for (target_index, target) in pose.targets.iter().enumerate() {
             let target_path = format!("{pose_path}.targets[{target_index}]");
             let runtime_name = resolve_target_runtime_name(
-                source_map,
+                &target_index,
                 &target.target,
                 &format!("{target_path}.target"),
             )?;
@@ -141,35 +152,49 @@ fn resolve_poses(
     Ok(poses)
 }
 
+fn index_motion_targets(source_map: &AuthoringSourceMap) -> MotionTargetIndex<'_> {
+    let mut targets = HashMap::new();
+    for entry in source_map
+        .entries
+        .iter()
+        .filter(|entry| entry.authored_path.starts_with("$.visual.nodes["))
+    {
+        let indexed = IndexedMotionTarget::Unique(entry.runtime_names.first().map(String::as_str));
+        match targets.entry(entry.authored_id.as_str()) {
+            Entry::Vacant(slot) => {
+                slot.insert(indexed);
+            }
+            Entry::Occupied(mut slot) => {
+                slot.insert(IndexedMotionTarget::Ambiguous);
+            }
+        }
+    }
+    targets
+}
+
 fn resolve_target_runtime_name(
-    source_map: &AuthoringSourceMap,
+    target_index: &MotionTargetIndex<'_>,
     target: &str,
     path: &str,
 ) -> Result<String, AuthoringDiagnostic> {
-    let mut matches = source_map.entries.iter().filter(|entry| {
-        entry.authored_id == target && entry.authored_path.starts_with("$.visual.nodes[")
-    });
-    let Some(entry) = matches.next() else {
-        return Err(AuthoringDiagnostic::new(
+    match target_index.get(target).copied() {
+        None => Err(AuthoringDiagnostic::new(
             path,
             "unknown_motion_target",
             format!("visual target '{target}' is not defined"),
-        ));
-    };
-    if matches.next().is_some() {
-        return Err(AuthoringDiagnostic::new(
+        )),
+        Some(IndexedMotionTarget::Ambiguous) => Err(AuthoringDiagnostic::new(
             path,
             "ambiguous_motion_target",
             format!("visual target '{target}' resolves to more than one authored node"),
-        ));
-    }
-    entry.runtime_names.first().cloned().ok_or_else(|| {
-        AuthoringDiagnostic::new(
+        )),
+        Some(IndexedMotionTarget::Unique(None)) => Err(AuthoringDiagnostic::new(
             path,
             "unsupported_motion_target",
             format!("visual target '{target}' has no animatable runtime object"),
-        )
-    })
+        )),
+        Some(IndexedMotionTarget::Unique(Some(runtime_name))) => Ok(runtime_name.to_owned()),
+    }
 }
 
 fn lower_tracks(
@@ -254,42 +279,40 @@ fn lower_tracks(
                 "motion tracks require at least two keyframes",
             )
         })?;
-        let expected_pose = &poses[first.pose_index];
-        for frame in &frames[1..] {
-            if !expected_pose.keys().eq(poses[frame.pose_index].keys()) {
-                return Err(AuthoringDiagnostic::new(
-                    format!("{track_path}.keyframes[{}].pose", frame.authored_index),
-                    "pose_shape_mismatch",
-                    "all poses referenced by a motion track must declare the same targets and transform properties",
-                ));
+        let expected_pose = poses
+            .get(first.pose_index)
+            .ok_or_else(|| pose_shape_mismatch(&track_path, first.authored_index))?;
+        for frame in frames.iter().skip(1) {
+            let pose = poses
+                .get(frame.pose_index)
+                .ok_or_else(|| pose_shape_mismatch(&track_path, frame.authored_index))?;
+            if !expected_pose.keys().eq(pose.keys()) {
+                return Err(pose_shape_mismatch(&track_path, frame.authored_index));
             }
         }
 
-        let keyframes = expected_pose
-            .keys()
-            .map(|(object, property)| {
-                let frames = frames
-                    .iter()
-                    .map(|frame| {
-                        let key = (object.clone(), *property);
-                        let value = poses[frame.pose_index]
-                            .get(&key)
-                            .copied()
-                            .expect("pose shapes were checked before lowering");
-                        json!({
-                            "frame": frame.frame,
-                            "value": value,
-                            "interpolation": interpolation_name(frame.interpolation)
-                        })
-                    })
-                    .collect::<Vec<_>>();
-                json!({
-                    "object": object,
-                    "property": property.name(),
-                    "frames": frames
-                })
-            })
-            .collect::<Vec<_>>();
+        let mut keyframes = Vec::with_capacity(expected_pose.len());
+        for key in expected_pose.keys() {
+            let (object, property) = key;
+            let mut property_frames = Vec::with_capacity(frames.len());
+            for frame in &frames {
+                let value = poses
+                    .get(frame.pose_index)
+                    .and_then(|pose| pose.get(key))
+                    .copied()
+                    .ok_or_else(|| pose_shape_mismatch(&track_path, frame.authored_index))?;
+                property_frames.push(json!({
+                    "frame": frame.frame,
+                    "value": value,
+                    "interpolation": interpolation_name(frame.interpolation)
+                }));
+            }
+            keyframes.push(json!({
+                "object": object,
+                "property": property.name(),
+                "frames": property_frames
+            }));
+        }
 
         fragments.push(RawSceneFragment {
             id: track.id.clone(),
@@ -309,6 +332,14 @@ fn lower_tracks(
     Ok(fragments)
 }
 
+fn pose_shape_mismatch(track_path: &str, authored_index: usize) -> AuthoringDiagnostic {
+    AuthoringDiagnostic::new(
+        format!("{track_path}.keyframes[{authored_index}].pose"),
+        "pose_shape_mismatch",
+        "all poses referenced by a motion track must declare the same targets and transform properties",
+    )
+}
+
 fn evaluate_frame_value(
     expression: &ScalarExpr,
     path: &str,
@@ -317,10 +348,17 @@ fn evaluate_frame_value(
     message: &str,
 ) -> Result<u64, AuthoringDiagnostic> {
     let value = evaluate_expression(expression, path, scope, Unit::Scalar)?;
-    if value < 0.0 || value.fract() != 0.0 || value > u64::MAX as f64 {
+    let rounded = value.round();
+    let rounding_tolerance =
+        (value.abs().max(1.0) * f64::EPSILON * FRAME_ROUNDING_ULPS).min(MAX_FRAME_ROUNDING_ERROR);
+    if !value.is_finite()
+        || rounded < 0.0
+        || (value - rounded).abs() > rounding_tolerance
+        || rounded >= u64::MAX as f64
+    {
         return Err(AuthoringDiagnostic::new(path, code, message));
     }
-    Ok(value as u64)
+    Ok(rounded as u64)
 }
 
 fn rewrite_motion_error_paths(mut error: AuthoringError, typed_count: usize) -> AuthoringError {

--- a/src/authoring/frontend/motion/validation.rs
+++ b/src/authoring/frontend/motion/validation.rs
@@ -1,12 +1,13 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use super::super::super::spec::{AuthoringDiagnostic, MotionSection};
+use super::super::super::spec::{AuthoringDiagnostic, MotionSection, TransformSpec};
 use super::super::validate_id;
 
 const MAX_POSES: usize = 1_000;
 const MAX_POSE_TARGETS: usize = 1_000;
 const MAX_TRACKS: usize = 1_000;
 const MAX_TRACK_KEYFRAMES: usize = 1_000;
+const MAX_EXPANDED_MOTION_KEYFRAMES: u64 = 10_000;
 const MAX_FPS: u64 = 240;
 
 pub(in crate::authoring::frontend) fn validate_motion(
@@ -24,6 +25,7 @@ pub(in crate::authoring::frontend) fn validate_motion(
     );
 
     let mut pose_ids = HashSet::new();
+    let mut pose_property_counts = HashMap::new();
     for (pose_index, pose) in motion.poses.iter().enumerate() {
         let pose_path = format!("$.motion.poses[{pose_index}]");
         validate_id(&pose.id, &format!("{pose_path}.id"), &mut diagnostics);
@@ -45,6 +47,7 @@ pub(in crate::authoring::frontend) fn validate_motion(
         );
 
         let mut target_ids = HashSet::new();
+        let mut property_count = 0_u64;
         for (target_index, target) in pose.targets.iter().enumerate() {
             let target_path = format!("{pose_path}.targets[{target_index}]");
             if target.target.trim().is_empty() {
@@ -73,7 +76,13 @@ pub(in crate::authoring::frontend) fn validate_motion(
                     "pose targets must declare at least one transform property",
                 ));
             }
+            property_count =
+                property_count.saturating_add(transform_property_count(&target.transform));
         }
+        pose_property_counts
+            .entry(pose.id.as_str())
+            .and_modify(|existing| *existing = (*existing).max(property_count))
+            .or_insert(property_count);
     }
 
     validate_count(
@@ -86,6 +95,7 @@ pub(in crate::authoring::frontend) fn validate_motion(
         &mut diagnostics,
     );
     let mut track_ids = HashSet::new();
+    let mut expanded_keyframe_count = 0_u64;
     for (track_index, track) in motion.tracks.iter().enumerate() {
         let track_path = format!("$.motion.tracks[{track_index}]");
         validate_id(&track.id, &format!("{track_path}.id"), &mut diagnostics);
@@ -121,9 +131,41 @@ pub(in crate::authoring::frontend) fn validate_motion(
                 ));
             }
         }
+
+        let property_count = track
+            .keyframes
+            .iter()
+            .filter_map(|keyframe| pose_property_counts.get(keyframe.pose.as_str()).copied())
+            .max()
+            .unwrap_or(0);
+        expanded_keyframe_count = expanded_keyframe_count.saturating_add(
+            property_count.saturating_mul(track.keyframes.len() as u64),
+        );
+        if expanded_keyframe_count > MAX_EXPANDED_MOTION_KEYFRAMES {
+            diagnostics.push(AuthoringDiagnostic::new(
+                format!("{track_path}.keyframes"),
+                "motion_keyframe_expansion_limit",
+                format!(
+                    "expanded motion keyframe count must not exceed {MAX_EXPANDED_MOTION_KEYFRAMES}"
+                ),
+            ));
+        }
     }
 
     diagnostics
+}
+
+fn transform_property_count(transform: &TransformSpec) -> u64 {
+    [
+        transform.x.is_some(),
+        transform.y.is_some(),
+        transform.rotation.is_some(),
+        transform.scale_x.is_some(),
+        transform.scale_y.is_some(),
+    ]
+    .into_iter()
+    .filter(|present| *present)
+    .count() as u64
 }
 
 fn validate_count(

--- a/src/authoring/frontend/motion/validation.rs
+++ b/src/authoring/frontend/motion/validation.rs
@@ -138,9 +138,8 @@ pub(in crate::authoring::frontend) fn validate_motion(
             .filter_map(|keyframe| pose_property_counts.get(keyframe.pose.as_str()).copied())
             .max()
             .unwrap_or(0);
-        expanded_keyframe_count = expanded_keyframe_count.saturating_add(
-            property_count.saturating_mul(track.keyframes.len() as u64),
-        );
+        expanded_keyframe_count = expanded_keyframe_count
+            .saturating_add(property_count.saturating_mul(track.keyframes.len() as u64));
         if expanded_keyframe_count > MAX_EXPANDED_MOTION_KEYFRAMES {
             diagnostics.push(AuthoringDiagnostic::new(
                 format!("{track_path}.keyframes"),

--- a/src/authoring/frontend/motion/validation.rs
+++ b/src/authoring/frontend/motion/validation.rs
@@ -25,7 +25,7 @@ pub(in crate::authoring::frontend) fn validate_motion(
     );
 
     let mut pose_ids = HashSet::new();
-    let mut pose_property_counts = HashMap::new();
+    let mut pose_property_counts: HashMap<&str, u64> = HashMap::new();
     for (pose_index, pose) in motion.poses.iter().enumerate() {
         let pose_path = format!("$.motion.poses[{pose_index}]");
         validate_id(&pose.id, &format!("{pose_path}.id"), &mut diagnostics);

--- a/tests/authoring_motion_contract.rs
+++ b/tests/authoring_motion_contract.rs
@@ -295,8 +295,7 @@ fn motion_diagnostics_point_to_authored_pose_and_track_paths() {
     ));
 
     let mut fractional_frame = document();
-    fractional_frame["motion"]["tracks"][0]["keyframes"][1]["frame"] =
-        literal(12.5, "scalar");
+    fractional_frame["motion"]["tracks"][0]["keyframes"][1]["frame"] = literal(12.5, "scalar");
     cases.push((
         fractional_frame,
         "invalid_frame",
@@ -371,10 +370,8 @@ fn aggregate_motion_keyframe_expansion_is_bounded() {
             .collect::<Vec<_>>();
         json!({ "id": id, "targets": targets })
     };
-    input["motion"]["poses"] = Value::Array(vec![
-        pose("first-pose", 0.0),
-        pose("second-pose", 1.0),
-    ]);
+    input["motion"]["poses"] =
+        Value::Array(vec![pose("first-pose", 0.0), pose("second-pose", 1.0)]);
 
     let track = |id: &str| {
         let keyframes = (0..=LAST_FRAME)
@@ -394,8 +391,7 @@ fn aggregate_motion_keyframe_expansion_is_bounded() {
             "keyframes": keyframes
         })
     };
-    input["motion"]["tracks"] =
-        Value::Array(vec![track("first-track"), track("second-track")]);
+    input["motion"]["tracks"] = Value::Array(vec![track("first-track"), track("second-track")]);
 
     let error = lower_authoring_json(&input.to_string())
         .expect_err("aggregate motion expansion must be rejected before lowering");

--- a/tests/authoring_motion_contract.rs
+++ b/tests/authoring_motion_contract.rs
@@ -295,7 +295,8 @@ fn motion_diagnostics_point_to_authored_pose_and_track_paths() {
     ));
 
     let mut fractional_frame = document();
-    fractional_frame["motion"]["tracks"][0]["keyframes"][1]["frame"] = literal(12.5, "scalar");
+    fractional_frame["motion"]["tracks"][0]["keyframes"][1]["frame"] =
+        literal(12.5, "scalar");
     cases.push((
         fractional_frame,
         "invalid_frame",
@@ -311,6 +312,102 @@ fn motion_diagnostics_point_to_authored_pose_and_track_paths() {
             error.diagnostics
         );
     }
+}
+
+#[test]
+fn near_integer_frame_expressions_round_deterministically() {
+    let mut input = document();
+    input["motion"]["tracks"][0]["keyframes"][1]["frame"] = json!({
+        "kind": "multiply",
+        "value": {
+            "kind": "add",
+            "left": literal(0.1, "scalar"),
+            "right": literal(0.2, "scalar")
+        },
+        "factor": 10.0
+    });
+
+    let lowered = lower(&input);
+    let animation = &lowered.scene["artboard"]["animations"][0];
+    let panel_x = keyframe_group(animation, "auth__motion_2dstage__panel__group", "x");
+    assert_eq!(panel_x["frames"][1]["frame"], 3);
+    assert_builds(lowered.scene);
+}
+
+#[test]
+fn aggregate_motion_keyframe_expansion_is_bounded() {
+    const TARGET_COUNT: usize = 50;
+    const LAST_FRAME: u64 = 20;
+
+    let mut input = document();
+    input["visual"]["nodes"] = Value::Array(
+        (0..TARGET_COUNT)
+            .map(|index| {
+                json!({
+                    "kind": "rectangle",
+                    "id": format!("target-{index}"),
+                    "width": literal(8.0, "px"),
+                    "height": literal(8.0, "px"),
+                    "fill": "#172554"
+                })
+            })
+            .collect(),
+    );
+
+    let pose = |id: &str, offset: f64| {
+        let targets = (0..TARGET_COUNT)
+            .map(|index| {
+                json!({
+                    "target": format!("target-{index}"),
+                    "transform": {
+                        "x": literal(index as f64 + offset, "px"),
+                        "y": literal(index as f64, "px"),
+                        "rotation": literal(offset, "degrees"),
+                        "scale_x": literal(1.0 + offset / 100.0, "scalar"),
+                        "scale_y": literal(1.0 + offset / 100.0, "scalar")
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        json!({ "id": id, "targets": targets })
+    };
+    input["motion"]["poses"] = Value::Array(vec![
+        pose("first-pose", 0.0),
+        pose("second-pose", 1.0),
+    ]);
+
+    let track = |id: &str| {
+        let keyframes = (0..=LAST_FRAME)
+            .map(|frame| {
+                json!({
+                    "frame": literal(frame as f64, "scalar"),
+                    "pose": if frame % 2 == 0 { "first-pose" } else { "second-pose" },
+                    "interpolation": "linear"
+                })
+            })
+            .collect::<Vec<_>>();
+        json!({
+            "id": id,
+            "fps": 60,
+            "duration_frames": literal(LAST_FRAME as f64, "scalar"),
+            "loop_type": "oneshot",
+            "keyframes": keyframes
+        })
+    };
+    input["motion"]["tracks"] =
+        Value::Array(vec![track("first-track"), track("second-track")]);
+
+    let error = lower_authoring_json(&input.to_string())
+        .expect_err("aggregate motion expansion must be rejected before lowering");
+    assert!(
+        has_diagnostic(
+            &error,
+            "motion_keyframe_expansion_limit",
+            "$.motion.tracks[1].keyframes"
+        ),
+        "missing aggregate motion expansion diagnostic: {:#?}",
+        error.diagnostics
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why this PR exists

The pre-work audit reconciled `ROADMAP.md`, the active Cairn todos, open and merged PRs, retained branches, delayed reviews, and exact-head CI.

- There were no open or draft PRs to continue.
- The retained feature branches correspond to already merged work; `agent/test-gitdata` is only a stale probe branch, not roadmap work.
- PR #158 had already reconciled the roadmap after the first named-pose/track slice.
- The unresolved findings on merged PR #157 are hardening of the existing in-progress P2 motion-authoring todo, not a new roadmap gap.

## Changes

- Cap the complete typed-motion document at 10,000 generated property-keyframe values before Cartesian lowering.
- Normalize only bounded floating-point round-off around whole frame and duration values; retain rejection of material fractional values.
- Index visual motion targets once rather than rescanning the full source map for every pose target.
- Replace the remaining checked-invariant panic shortcut with structured `pose_shape_mismatch` diagnostics at authored paths.
- Consolidate pose-shape error construction and avoid cloned lookup keys in the lowering loop.
- Record the hardened boundary and audit result in the Cairn authoring contract and active motion todo.

## TDD evidence

### RED

Exact head `35a70b0` in Actions run `30818628328` failed only on the intended new contracts after formatting was normalized:

- `aggregate_motion_keyframe_expansion_is_bounded`: a 10,500-value Cartesian expansion was accepted.
- `near_integer_frame_expressions_round_deterministically`: `(0.1 + 0.2) × 10` was rejected as a fractional frame.

The five pre-existing motion contracts passed in that run.

### GREEN

Exact head `3568f8553a44a23d7576d84c6dbda565a16cbfca` passed CI run 706 across:

- `cargo fmt --check`;
- Clippy with warnings denied;
- the complete locked Rust suite, including both former RED contracts;
- browser contracts;
- Cairn `scan` and `lint`;
- official-runtime evaluation evidence;
- demo validation;
- site validation;
- Playwright regression and visual regression.

## Review provenance

This PR addresses four substantive delayed review threads on PR #157: aggregate expansion, panic-free invariant handling, robust integer-frame evaluation, and target-lookup complexity. The separate comment that Cairn verification was absent is contradicted by PR #157's recorded `cairn scan`/`cairn lint` evidence and exact-head CI run 694; no architecture change was required for that comment.