### PR TITLE
Preserve one-ULP motion frame normalization

### DIFF
--- a/meta/contracts/authoring.md
+++ b/meta/contracts/authoring.md
@@ -28,16 +28,18 @@ with authored visual targets, scalar-expression frame timing, `hold` or `linear`
 interpolation, and `oneshot`, `loop`, or `pingpong` loop behavior. Every pose used
 by one track declares the same target/property shape. Frame and duration
 expressions must resolve to non-negative whole numbers; bounded floating-point
-round-off around a whole number is normalized deterministically, while material
-fractional values are rejected. The complete typed-motion document may expand to
-at most 10,000 canonical property-keyframe values, preventing individually valid
-poses and tracks from creating an unbounded Cartesian expansion. Tracks lower
-through the canonical builder, retain deterministic runtime names, and map errors
-and runtime objects back to `$.motion.tracks` and `$.motion.poses`. Visual motion
-targets are indexed once from the authored source map, and failed invariants return
-structured authored diagnostics rather than panicking. Raw state-machine escapes
-may reference generated track runtime names in the same document because final
-canonical validation occurs only after typed animations are present. Shared easing
+round-off around a whole number is normalized deterministically through a capped
+multi-ULP window that never becomes narrower than one representable step at the
+evaluated magnitude, while material fractional values are rejected. The complete
+typed-motion document may expand to at most 10,000 canonical property-keyframe
+values, preventing individually valid poses and tracks from creating an unbounded
+Cartesian expansion. Tracks lower through the canonical builder, retain
+deterministic runtime names, and map errors and runtime objects back to
+`$.motion.tracks` and `$.motion.poses`. Visual motion targets are indexed once from
+the authored source map, and failed invariants return structured authored
+diagnostics rather than panicking. Raw state-machine escapes may reference
+generated track runtime names in the same document because final canonical
+validation occurs only after typed animations are present. Shared easing
 definitions, semantic motion helpers, non-transform property tracks, and typed
 statecharts remain separate roadmap slices.
 

--- a/meta/todos/todo.motion-authoring-compiler.md
+++ b/meta/todos/todo.motion-authoring-compiler.md
@@ -54,6 +54,15 @@ PR #159 records that follow-up:
 - the checked pose-shape invariant now returns an authored `pose_shape_mismatch` diagnostic rather than using a panic shortcut;
 - exact implementation head `197d4cd` passed rustfmt, Clippy, the complete Rust suite, browser contracts, and Cairn scan/lint in CI run 704 before the durable contract evidence was committed.
 
+A review arriving immediately after #159 merged found that its absolute `1e-9`
+rounding cap could be smaller than one floating-point ULP for large supported frame
+values. PR #160 continues the same P2 hardening rather than opening a roadmap item:
+
+- exact-head RED `4fd80d7` in CI run 708 passed formatting, Clippy, browser contracts, and every pre-existing Rust test, while the new large-frame regression failed with `invalid_frame`;
+- the regression evaluates `(0.1 + 0.2) × 1_000_000_000`, which is one representable step above frame `300_000_000`;
+- frame normalization now derives the actual ULP at the evaluated magnitude, retains the bounded eight-ULP/`1e-9` window at ordinary magnitudes, and floors that window at one ULP only when representable spacing is larger;
+- exact implementation head `210929e` passed rustfmt, Clippy, the complete Rust suite, browser contracts, and Cairn scan/lint in CI run 709 before this durable contract evidence was committed.
+
 The roadmap tracks incremental typed authoring operations as a separate P3
 milestone rather than leaving that AI-skill unblock condition implicit.
 

--- a/src/authoring/frontend/motion.rs
+++ b/src/authoring/frontend/motion.rs
@@ -61,7 +61,7 @@ const TRANSFORM_PROPERTIES: [TransformProperty; 5] = [
     TransformProperty::ScaleY,
 ];
 const FRAME_ROUNDING_ULPS: f64 = 8.0;
-const MAX_FRAME_ROUNDING_ERROR: f64 = 1e-9;
+const MAX_FRAME_ROUNDING_WINDOW: f64 = 1e-9;
 
 type PoseValues = BTreeMap<(String, TransformProperty), f64>;
 type MotionTargetIndex<'a> = HashMap<&'a str, IndexedMotionTarget<'a>>;
@@ -340,6 +340,14 @@ fn pose_shape_mismatch(track_path: &str, authored_index: usize) -> AuthoringDiag
     )
 }
 
+fn frame_rounding_tolerance(value: f64) -> f64 {
+    let magnitude = value.abs().max(1.0);
+    let one_ulp = f64::from_bits(magnitude.to_bits() + 1) - magnitude;
+    (one_ulp * FRAME_ROUNDING_ULPS)
+        .min(MAX_FRAME_ROUNDING_WINDOW)
+        .max(one_ulp)
+}
+
 fn evaluate_frame_value(
     expression: &ScalarExpr,
     path: &str,
@@ -349,13 +357,10 @@ fn evaluate_frame_value(
 ) -> Result<u64, AuthoringDiagnostic> {
     let value = evaluate_expression(expression, path, scope, Unit::Scalar)?;
     let rounded = value.round();
-    let rounding_tolerance =
-        (value.abs().max(1.0) * f64::EPSILON * FRAME_ROUNDING_ULPS).min(MAX_FRAME_ROUNDING_ERROR);
-    if !value.is_finite()
-        || rounded < 0.0
-        || (value - rounded).abs() > rounding_tolerance
-        || rounded >= u64::MAX as f64
-    {
+    if !value.is_finite() || rounded < 0.0 || rounded >= u64::MAX as f64 {
+        return Err(AuthoringDiagnostic::new(path, code, message));
+    }
+    if (value - rounded).abs() > frame_rounding_tolerance(value) {
         return Err(AuthoringDiagnostic::new(path, code, message));
     }
     Ok(rounded as u64)

--- a/tests/authoring_motion_contract.rs
+++ b/tests/authoring_motion_contract.rs
@@ -334,6 +334,28 @@ fn near_integer_frame_expressions_round_deterministically() {
 }
 
 #[test]
+fn large_near_integer_frame_expressions_accept_one_ulp_roundoff() {
+    let mut input = document();
+    input["motion"]["tracks"][0]["duration_frames"] = literal(300_000_000.0, "scalar");
+    input["motion"]["tracks"][0]["keyframes"][1]["frame"] = json!({
+        "kind": "multiply",
+        "value": {
+            "kind": "add",
+            "left": literal(0.1, "scalar"),
+            "right": literal(0.2, "scalar")
+        },
+        "factor": 1_000_000_000.0
+    });
+
+    let lowered = lower(&input);
+    let animation = &lowered.scene["artboard"]["animations"][0];
+    let panel_x = keyframe_group(animation, "auth__motion_2dstage__panel__group", "x");
+    assert_eq!(animation["duration"], 300_000_000);
+    assert_eq!(panel_x["frames"][1]["frame"], 300_000_000);
+    assert_builds(lowered.scene);
+}
+
+#[test]
 fn aggregate_motion_keyframe_expansion_is_bounded() {
     const TARGET_COUNT: usize = 50;
     const LAST_FRAME: u64 = 20;


### PR DESCRIPTION
## Audit and scope

This is a focused follow-up to the review that arrived immediately after PR #159 merged.

- The earlier repository audit found no separate roadmap gap: this remains hardening of the existing in-progress P2 motion-authoring todo.
- No other open or draft PR existed before this follow-up was opened.
- The finding was valid: the absolute `1e-9` cap could be narrower than one representable floating-point step at large supported frame values.

## Change

- Derive the actual ULP at the evaluated frame magnitude.
- Keep the bounded multi-ULP normalization window used for ordinary values.
- Floor that window at one ULP only when representable spacing is larger than the ordinary absolute cap.
- Preserve the early finite, non-negative, and `u64` range checks.
- Preserve rejection of material fractional frames.
- Extract the calculation into one `frame_rounding_tolerance` helper.
- Record the boundary and evidence in the existing Cairn authoring contract and P2 todo.

## TDD evidence

### RED

Exact head `4fd80d7e29fba3b7abdf172e186cf74c3d5a29a9` in CI run 708 passed formatting, Clippy, browser contracts, and every pre-existing Rust test. Only the new contract `large_near_integer_frame_expressions_accept_one_ulp_roundoff` failed with `invalid_frame`.

The regression evaluates `(0.1 + 0.2) × 1_000_000_000`, whose `f64` result is `300000000.00000006`, exactly one representable step above frame `300000000`.

### GREEN

Implementation head `210929e6ac0d7ccb52c4635239edf542bac001b3` passed CI run 709 across formatting, Clippy, the complete Rust suite, browser contracts, Cairn, official-runtime evidence, demo, site, Playwright, and visual regression.

Final exact head `b06a3564ddf709758665176555f55d242e2d199a` passed CI run 711 across the same complete gate set after the Cairn contract and todo evidence were committed.

## Review provenance

Addresses the unresolved late review thread on PR #159, “Avoid capping the tolerance below one ULP.” The implementation preserves strict whole-frame semantics while making deterministic normalization valid across the supported frame magnitude range.