### PR TITLE
Report aggregate motion expansion limit once

### DIFF
--- a/meta/contracts/authoring.md
+++ b/meta/contracts/authoring.md
@@ -33,10 +33,12 @@ multi-ULP window that never becomes narrower than one representable step at the
 evaluated magnitude, while material fractional values are rejected. The complete
 typed-motion document may expand to at most 10,000 canonical property-keyframe
 values, preventing individually valid poses and tracks from creating an unbounded
-Cartesian expansion. Tracks lower through the canonical builder, retain
-deterministic runtime names, and map errors and runtime objects back to
-`$.motion.tracks` and `$.motion.poses`. Visual motion targets are indexed once from
-the authored source map, and failed invariants return structured authored
+Cartesian expansion. The validator reports this aggregate limit once, at the first
+track that causes the document to cross the budget, while continuing to validate
+later tracks for unrelated authored errors. Tracks lower through the canonical
+builder, retain deterministic runtime names, and map errors and runtime objects
+back to `$.motion.tracks` and `$.motion.poses`. Visual motion targets are indexed
+once from the authored source map, and failed invariants return structured authored
 diagnostics rather than panicking. Raw state-machine escapes may reference
 generated track runtime names in the same document because final canonical
 validation occurs only after typed animations are present. Shared easing

--- a/meta/todos/todo.motion-authoring-compiler.md
+++ b/meta/todos/todo.motion-authoring-compiler.md
@@ -63,6 +63,15 @@ values. PR #160 continues the same P2 hardening rather than opening a roadmap it
 - frame normalization now derives the actual ULP at the evaluated magnitude, retains the bounded eight-ULP/`1e-9` window at ordinary magnitudes, and floors that window at one ULP only when representable spacing is larger;
 - exact implementation head `210929e` passed rustfmt, Clippy, the complete Rust suite, browser contracts, and Cairn scan/lint in CI run 709 before this durable contract evidence was committed.
 
+A final unresolved Qodo thread on #159 found that the monotonic aggregate budget
+emitted the same limit diagnostic for every track after the first crossing. PR #161
+continues the same P2 diagnostic hardening:
+
+- exact-head RED `4541ade` in CI run 713 passed rustfmt, Clippy, browser contracts, every pre-existing Rust test, and the existing 10,500-value rejection contract; only the new three-track regression failed because it received two limit diagnostics instead of one;
+- the regression uses three individually valid 5,250-value tracks and requires exactly one `motion_keyframe_expansion_limit` at the second track, which first crosses the 10,000-value budget;
+- validation now compares the aggregate count before and after each track, reports only the first threshold crossing, and continues validating later tracks for unrelated diagnostics;
+- exact implementation head `e67bb23` passed rustfmt, Clippy, the complete Rust suite, browser contracts, and Cairn scan/lint in CI run 714 before this durable contract evidence was committed.
+
 The roadmap tracks incremental typed authoring operations as a separate P3
 milestone rather than leaving that AI-skill unblock condition implicit.
 

--- a/src/authoring/frontend/motion/validation.rs
+++ b/src/authoring/frontend/motion/validation.rs
@@ -138,9 +138,12 @@ pub(in crate::authoring::frontend) fn validate_motion(
             .filter_map(|keyframe| pose_property_counts.get(keyframe.pose.as_str()).copied())
             .max()
             .unwrap_or(0);
+        let previous_expanded_keyframe_count = expanded_keyframe_count;
         expanded_keyframe_count = expanded_keyframe_count
             .saturating_add(property_count.saturating_mul(track.keyframes.len() as u64));
-        if expanded_keyframe_count > MAX_EXPANDED_MOTION_KEYFRAMES {
+        if previous_expanded_keyframe_count <= MAX_EXPANDED_MOTION_KEYFRAMES
+            && expanded_keyframe_count > MAX_EXPANDED_MOTION_KEYFRAMES
+        {
             diagnostics.push(AuthoringDiagnostic::new(
                 format!("{track_path}.keyframes"),
                 "motion_keyframe_expansion_limit",

--- a/tests/authoring_motion_expansion_contract.rs
+++ b/tests/authoring_motion_expansion_contract.rs
@@ -1,0 +1,87 @@
+use rive_cli::authoring::lower_authoring_json;
+use serde_json::{Value, json};
+
+fn literal(value: f64, unit: &str) -> Value {
+    json!({ "kind": "literal", "value": value, "unit": unit })
+}
+
+#[test]
+fn aggregate_motion_expansion_reports_only_the_first_limit_crossing() {
+    const TARGET_COUNT: usize = 50;
+    const LAST_FRAME: u64 = 20;
+
+    let targets = (0..TARGET_COUNT)
+        .map(|index| {
+            json!({
+                "target": format!("target-{index}"),
+                "transform": {
+                    "x": literal(index as f64, "px"),
+                    "y": literal(index as f64, "px"),
+                    "rotation": literal(0.0, "degrees"),
+                    "scale_x": literal(1.0, "scalar"),
+                    "scale_y": literal(1.0, "scalar")
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    let track = |id: &str| {
+        let keyframes = (0..=LAST_FRAME)
+            .map(|frame| {
+                json!({
+                    "frame": literal(frame as f64, "scalar"),
+                    "pose": "expanded-pose",
+                    "interpolation": "linear"
+                })
+            })
+            .collect::<Vec<_>>();
+        json!({
+            "id": id,
+            "fps": 60,
+            "duration_frames": literal(LAST_FRAME as f64, "scalar"),
+            "loop_type": "oneshot",
+            "keyframes": keyframes
+        })
+    };
+    let input = json!({
+        "authoring_format_version": 0,
+        "artboard": {
+            "id": "motion-stage",
+            "width": { "value": 320.0, "unit": "px" },
+            "height": { "value": 200.0, "unit": "px" }
+        },
+        "visual": { "nodes": [] },
+        "motion": {
+            "poses": [
+                {
+                    "id": "expanded-pose",
+                    "targets": targets
+                }
+            ],
+            "tracks": [
+                track("first-track"),
+                track("second-track"),
+                track("third-track")
+            ]
+        },
+        "behavior": {}
+    });
+
+    let error = lower_authoring_json(&input.to_string())
+        .expect_err("aggregate motion expansion must fail at its first limit crossing");
+    let expansion_diagnostics = error
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "motion_keyframe_expansion_limit")
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        expansion_diagnostics.len(),
+        1,
+        "the aggregate limit should be reported once: {:#?}",
+        error.diagnostics
+    );
+    assert_eq!(
+        expansion_diagnostics[0].path,
+        "$.motion.tracks[1].keyframes"
+    );
+}


### PR DESCRIPTION
## Audit and scope

This focused follow-up addresses the final unresolved Qodo thread on merged PR #159.

- The repository audit found no new roadmap gap; this is diagnostic hardening of the active P2 motion-authoring todo.
- The aggregate counter is monotonic, but the previous validator emitted the same limit diagnostic for every later track after crossing 10,000 generated property-keyframe values.
- No existing open or draft PR preceded this follow-up.

## Change

- Compare the aggregate generated-keyframe count immediately before and after each track.
- Emit `motion_keyframe_expansion_limit` only when the total crosses from `<= 10,000` to `> 10,000`.
- Continue validating later tracks, preserving unrelated diagnostics.
- Add an exact authored-path regression and record the behavior in the existing Cairn contract and P2 todo.

## TDD evidence

### RED

Exact head `4541adeda6c6ed0dd5576b7a5f4448c0319f1f0b` in CI run 713 passed formatting, Clippy, browser contracts, every pre-existing Rust test, and the existing aggregate-expansion rejection contract. Only the new three-track regression failed because two limit diagnostics were emitted; it expected exactly one at `$.motion.tracks[1].keyframes`.

### GREEN

Implementation head `e67bb23ef63a934d6b54201d0f5ffe70dd4fce3c` in CI run 714 passed formatting, Clippy, the complete Rust suite, browser contracts, and Cairn scan/lint.

Final exact head `7f0228c70c948da5468b55e667c465a284619b85` passed CI run 716 across formatting, Clippy, the complete Rust suite, browser contracts, Cairn, official-runtime evidence, demo validation, site validation, Playwright regression, and visual regression. The first attempt hit the unrelated renderer `Promise was collected` flake; the failed-job rerun passed on the unchanged head, so no source change was made.

## Review provenance

Addresses the Qodo duplicate-diagnostic thread on PR #159. The implementation reports the first aggregate threshold crossing once while continuing all later-track validation.