### PR TITLE
test(repair): harden duplicate-reference contract

### DIFF
--- a/meta/todos/todo.repair-engine-modularization.md
+++ b/meta/todos/todo.repair-engine-modularization.md
@@ -39,6 +39,15 @@ module split:
 - the focused unit regression and end-to-end RepairEngine contract passed before the implementation commit was persisted;
 - exact implementation head `eefe2cd` passed the Rust 1.88 minimum in run `31182568911` and the complete repository suite in run `31182568545`: rustfmt, Clippy, all Rust tests, browser contracts, Cairn architecture validation, official-runtime evidence, demo, site, Playwright, and visual regression all passed before this durable evidence was committed.
 
+A late review on merged PR #166 found that the end-to-end contract also pinned the
+current retry count and indexed the second attempt directly. PR #167 hardens the
+same completed correctness gate without changing production behavior:
+
+- the contract now searches all recorded attempts for the deterministic `foo_3` rename rather than requiring exactly one retry and indexing `attempts[1]`;
+- the repaired names and the final ambiguous-reference policy remain the primary assertions;
+- exact test-hardening head `85dabaa` passed the Rust 1.88 minimum in run `31184278616` and the complete repository suite in run `31184279807`: rustfmt, Clippy, all Rust tests, browser contracts, Cairn architecture validation, official-runtime evidence, demo, site, Playwright, and visual regression all passed before this evidence was committed;
+- this is review remediation inside the existing P0 gate, not a new roadmap item or the beginning of the deferred P4 module split.
+
 ## Acceptance criteria
 
 - The immediate duplicate-reference regression is fixed without changing unrelated repair behavior.

--- a/tests/repair_duplicate_reference_contract.rs
+++ b/tests/repair_duplicate_reference_contract.rs
@@ -36,13 +36,12 @@ fn duplicate_name_repair_keeps_existing_reference_on_first_object() {
     let result = RepairEngine::default()
         .repair(input, 0)
         .expect("duplicate names should be repaired");
-    assert_eq!(result.total_retries, 1);
-    assert!(
-        result.attempts[1]
+    assert!(result.attempts.iter().any(|attempt| {
+        attempt
             .fixes_applied
             .iter()
             .any(|fix| fix == "renamed duplicate 'foo' to 'foo_3'")
-    );
+    }));
 
     let children = result.scene_json["artboard"]["children"]
         .as_array()


### PR DESCRIPTION
## Scope

Address the late unresolved review on merged PR #166 before beginning new roadmap work.

The end-to-end duplicate-reference contract correctly pins the repaired names and final ambiguous-reference policy, but it also asserted `total_retries == 1` and indexed `attempts[1]`. Those details belong to the current RepairEngine sequencing, not to the semantic contract.

## Change

- search all repair attempts for the expected deterministic `foo -> foo_3` rename;
- remove the exact retry-count assertion and direct attempt indexing;
- retain the final-state assertions for `foo`, `foo_2`, `foo_3`, and the reference remaining on `foo`;
- make no production-code or behavior change;
- record the review rationale and evidence in the existing repair-engine Cairn todo.

## Roadmap reconciliation

This is review remediation for the completed P0 correctness gate in the existing repair-engine Cairn todo. It does not reopen the deferred P4 modularization or create a new roadmap item. The next product work remains the characterization stage of the one-pass Authoring compiler gate, after remaining late-review correctness findings are reconciled.

## Verification

- test-hardening head `85dabaa`: Rust 1.88 minimum run `31184278616` passed; complete CI run `31184279807` passed;
- final exact head `20a401d`: Rust 1.88 minimum run `31184670180` passed; complete CI run `31184670400` passed;
- final CI includes rustfmt, Clippy, all Rust tests, browser contracts, Cairn architecture validation, official-runtime evidence, demo, site, Playwright, and visual regression.