### PR TITLE
fix(authoring): route primary raw geometry dimensions

### DIFF
--- a/meta/todos/todo.motion-authoring-compiler.md
+++ b/meta/todos/todo.motion-authoring-compiler.md
@@ -117,6 +117,18 @@ todo rather than opening a parallel feature milestone:
 - zero compatible bindings return `unsupported_motion_property`, exactly one lowers normally, and more than one returns `ambiguous_motion_property_target` at the authored property path;
 - public `SourceMapEntry` serialization remains unchanged, avoiding a source-map format break while the compiler gains checked internal bindings.
 
+A late review on PR #165 found that treating primary identity as the `Transform`
+role made a root raw parametric object lose its geometry capability. PR #168
+continues the same P2 correctness work rather than creating a roadmap gap:
+
+- exact regression-only head `3189283` passed the Rust 1.88 minimum in run `31185371891`, rustfmt, Clippy, all pre-existing tests, and browser contracts; CI run `31185371412` failed only because the new raw-rectangle contract received `unsupported_motion_property` at `$.motion.poses[0].targets[0].width`;
+- runtime bindings now record primary identity independently from their semantic `Geometry` or `Other` role;
+- transform and opacity properties select the primary binding, while width and height select parametric geometry; the canonical builder property registry remains the final compatibility check for both paths;
+- a primary raw rectangle can therefore own `x`, `width`, and `height`, while a typed shape still routes dimensions to its child geometry and multiple compatible raw geometries remain ambiguous;
+- the obsolete `Transform` role and its duplicated role-matching path were removed, and property selection is consolidated in `PoseProperty::supports_runtime_object`;
+- exact implementation head `1fbfba1` passed the Rust 1.88 minimum in run `31185735792` and the complete repository suite in run `31185735638`: rustfmt, Clippy, all Rust tests, browser contracts, Cairn architecture validation, official-runtime evidence, demo, site, Playwright, and visual regression;
+- the public schema and source-map format are unchanged.
+
 ## Architecture gate before further feature expansion
 
 The public boundary remains:

--- a/src/authoring/frontend/motion/property.rs
+++ b/src/authoring/frontend/motion/property.rs
@@ -22,7 +22,6 @@ pub(super) enum PoseProperty {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum MotionRuntimeRole {
-    Transform,
     Geometry,
     Other,
 }
@@ -31,6 +30,7 @@ pub(super) enum MotionRuntimeRole {
 pub(super) struct MotionRuntimeObject<'a> {
     pub(super) runtime_name: &'a str,
     pub(super) object_type: &'a str,
+    is_primary: bool,
     role: MotionRuntimeRole,
 }
 
@@ -40,9 +40,7 @@ impl<'a> MotionRuntimeObject<'a> {
         object_type: &'a str,
         is_primary: bool,
     ) -> Self {
-        let role = if is_primary {
-            MotionRuntimeRole::Transform
-        } else if matches!(
+        let role = if matches!(
             object_type,
             "ellipse" | "polygon" | "rectangle" | "star" | "triangle"
         ) {
@@ -53,6 +51,7 @@ impl<'a> MotionRuntimeObject<'a> {
         Self {
             runtime_name,
             object_type,
+            is_primary,
             role,
         }
     }
@@ -87,13 +86,15 @@ impl PoseProperty {
         }
     }
 
-    fn runtime_role(self) -> MotionRuntimeRole {
-        match self {
+    fn supports_runtime_object(self, runtime_object: MotionRuntimeObject<'_>) -> bool {
+        let has_target_role = match self {
             Self::X | Self::Y | Self::Rotation | Self::ScaleX | Self::ScaleY | Self::Opacity => {
-                MotionRuntimeRole::Transform
+                runtime_object.is_primary
             }
-            Self::Width | Self::Height => MotionRuntimeRole::Geometry,
-        }
+            Self::Width | Self::Height => runtime_object.role == MotionRuntimeRole::Geometry,
+        };
+        has_target_role
+            && property_key_for_object(runtime_object.object_type, self.name()).is_some()
     }
 
     fn expression(self, target: &PoseTargetSpec) -> Option<&ScalarExpr> {
@@ -228,10 +229,10 @@ fn target_for_property<'a>(
     runtime_objects: &[MotionRuntimeObject<'a>],
     property: PoseProperty,
 ) -> PropertyTarget<'a> {
-    let mut matches = runtime_objects.iter().copied().filter(|runtime_object| {
-        runtime_object.role == property.runtime_role()
-            && property_key_for_object(runtime_object.object_type, property.name()).is_some()
-    });
+    let mut matches = runtime_objects
+        .iter()
+        .copied()
+        .filter(|runtime_object| property.supports_runtime_object(*runtime_object));
     let Some(first) = matches.next() else {
         return PropertyTarget::Unsupported;
     };
@@ -287,7 +288,7 @@ mod tests {
     }
 
     #[test]
-    fn properties_require_exactly_one_compatible_runtime_role() {
+    fn properties_require_exactly_one_compatible_runtime_target() {
         let runtime_objects = [
             MotionRuntimeObject::from_binding("shape", "shape", true),
             MotionRuntimeObject::from_binding("geometry", "rectangle", false),
@@ -300,6 +301,24 @@ mod tests {
         assert_eq!(
             target_for_property(&runtime_objects, PoseProperty::Width),
             PropertyTarget::Unique(runtime_objects[1])
+        );
+
+        let primary_geometry = [MotionRuntimeObject::from_binding(
+            "raw-rectangle",
+            "rectangle",
+            true,
+        )];
+        assert_eq!(
+            target_for_property(&primary_geometry, PoseProperty::X),
+            PropertyTarget::Unique(primary_geometry[0])
+        );
+        assert_eq!(
+            target_for_property(&primary_geometry, PoseProperty::Width),
+            PropertyTarget::Unique(primary_geometry[0])
+        );
+        assert_eq!(
+            target_for_property(&primary_geometry, PoseProperty::Height),
+            PropertyTarget::Unique(primary_geometry[0])
         );
 
         let ambiguous_geometry = [

--- a/tests/authoring_motion_dimension_contract.rs
+++ b/tests/authoring_motion_dimension_contract.rs
@@ -127,6 +127,40 @@ fn shape_dimension_tracks_route_to_parametric_geometry() {
 }
 
 #[test]
+fn primary_raw_parametric_geometry_routes_transform_and_dimensions() {
+    let mut input = document();
+    input["visual"]["nodes"][0] = json!({
+        "kind": "raw_scene_object",
+        "id": "card",
+        "object": {
+            "type": "rectangle",
+            "name": "RawRectangle",
+            "width": 80.0,
+            "height": 48.0,
+            "origin_x": 0.5,
+            "origin_y": 0.5
+        }
+    });
+
+    let lowered = lower(&input);
+    let animation = &lowered.scene["artboard"]["animations"][0];
+
+    let x = keyframe_group(animation, "RawRectangle", "x");
+    assert_eq!(x["frames"][0]["value"], 40.0);
+    assert_eq!(x["frames"][1]["value"], 160.0);
+
+    let width = keyframe_group(animation, "RawRectangle", "width");
+    assert_eq!(width["frames"][0]["value"], 80.0);
+    assert_eq!(width["frames"][1]["value"], 160.0);
+
+    let height = keyframe_group(animation, "RawRectangle", "height");
+    assert_eq!(height["frames"][0]["value"], 48.0);
+    assert_eq!(height["frames"][1]["value"], 96.0);
+
+    assert_builds(lowered.scene);
+}
+
+#[test]
 fn dimension_schema_is_optional_and_expression_typed() {
     let schema = authoring_schema();
     let pose_target = &schema["$defs"]["PoseTargetSpec"];


### PR DESCRIPTION
## Scope

Address the actionable late review on merged PR #165 before beginning the one-pass compiler characterization stage.

A raw SceneSpec target whose only named runtime binding is a parametric geometry, such as a root `rectangle`, is both the primary transform target and the geometry target. The previous classifier assigned every primary binding the `Transform` role, so `width` and `height` incorrectly reported `unsupported_motion_property`.

## Change

- record primary identity independently from semantic `Geometry`/`Other` classification;
- select transform and opacity properties through the primary binding;
- select width and height through parametric geometry bindings;
- retain the canonical builder property registry as the final compatibility check;
- remove the obsolete `Transform` role and consolidate selection in `PoseProperty::supports_runtime_object`;
- cover the root raw-rectangle case in both focused unit and public integration contracts;
- record the review rationale and exact evidence in the existing P2 Cairn todo.

A primary raw rectangle can now own `x`, `width`, and `height`. Typed shapes continue to route transforms to the shape and dimensions to child geometry, while multiple compatible raw geometries remain ambiguous.

## Roadmap and review reconciliation

This is bounded correctness remediation inside the existing P2 motion-authoring todo. It does not add a schema feature or create a roadmap item. The separate late comment requesting no-op test modules in declaration files was not implemented: the changed routing module already has co-located unit coverage, and the public behavior is pinned by the dedicated integration contract.

## TDD and verification

- RED head `3189283`: Rust 1.88 run `31185371891` passed; CI run `31185371412` passed rustfmt, Clippy, browser contracts, and all pre-existing tests, then failed only on the new contract with `unsupported_motion_property` at `$.motion.poses[0].targets[0].width`;
- implementation head `1fbfba1`: Rust 1.88 run `31185735792` passed; complete CI run `31185735638` passed;
- final exact head `19c6706`: Rust 1.88 run `31186187816` passed; complete CI run `31186187602` passed;
- complete CI includes rustfmt, Clippy, all Rust tests, browser contracts, Cairn architecture validation, official-runtime evidence, demo, site, Playwright, and visual regression.