### PR TITLE
test(authoring): characterize mixed compiler boundary

### DIFF
--- a/meta/todos/todo.motion-authoring-compiler.md
+++ b/meta/todos/todo.motion-authoring-compiler.md
@@ -129,6 +129,14 @@ continues the same P2 correctness work rather than creating a roadmap gap:
 - exact implementation head `1fbfba1` passed the Rust 1.88 minimum in run `31185735792` and the complete repository suite in run `31185735638`: rustfmt, Clippy, all Rust tests, browser contracts, Cairn architecture validation, official-runtime evidence, demo, site, Playwright, and visual regression;
 - the public schema and source-map format are unchanged.
 
+The first one-pass compiler characterization slice remains within this P2 todo.
+PR #169 pins the migration boundary before production architecture changes:
+
+- `tests/authoring_compiler_characterization.rs` covers two typed tracks followed by two raw animation escapes, a raw state machine referencing the second typed track, repeated deterministic lowering, exact animation and source-map ordering, exact authored IDs and paths, runtime names, scene paths, canonical-builder acceptance, and a second-pass raw diagnostic rewritten across the generated two-track prefix;
+- initial head `eff8fbb` passed the Rust 1.88 minimum in run `31187208884` and browser contracts, while CI run `31187208893` stopped only at `cargo fmt --check` before Clippy or Rust tests; no behavioral conclusion was drawn from that formatting-only failure;
+- formatting-only head `f035f70` passed the Rust 1.88 minimum in run `31187442874` and the complete repository suite in run `31187441981`: rustfmt, Clippy, all Rust tests, browser contracts, Cairn architecture validation, official-runtime evidence, demo, site, Playwright, and visual regression;
+- the slice changes no production code, public schema, source-map format, or product behavior; it establishes the exact contract that the one-pass compiler state must preserve while deleting the current clone, second lower, raw-fragment bridge, and string-offset repair path.
+
 ## Architecture gate before further feature expansion
 
 The public boundary remains:
@@ -138,7 +146,7 @@ The public boundary remains:
 Before typed behavior/statecharts or another broad Authoring feature slice, deepen
 the implementation behind that boundary in this order:
 
-1. Add characterization contracts for mixed typed/raw animation, raw state-machine references to typed tracks, deterministic ordering, exact diagnostic paths, and source-map identity.
+1. **Characterized in PR #169.** Preserve mixed typed/raw animation, raw state-machine references to typed tracks, deterministic ordering, exact diagnostic paths, and source-map identity.
 2. Introduce one internal `AuthoringCompiler` state holding resolved symbols, a canonical scene draft, the runtime-name registry, checked runtime bindings, the motion-target index, and the source-map builder.
 3. Lower assets and visuals into that state once; lower typed motion directly into the same scene draft; append raw escapes afterward; construct and validate canonical `SceneSpec` once.
 4. Remove typed-motion conversion back into `RawSceneFragment`, the cloned/cleared second `AuthoringSpec`, the second full visual lowering, and string-based diagnostic/source-path repair.
@@ -153,7 +161,7 @@ solely because they exceed a line-count guideline.
 
 ## Remaining
 
-- Complete the one-pass compiler architecture gate above before behavior/statecharts or broad Authoring expansion.
+- Complete compiler-state and one-pass lowering steps 2–7 above before behavior/statecharts or broad Authoring expansion.
 - Semantic entrance, exit, stagger, spring, bounce, and similar motion helpers.
 - Color and additional non-transform property tracks.
 - A complex animated showcase with retained official-runtime frame evidence.

--- a/tests/authoring_compiler_characterization.rs
+++ b/tests/authoring_compiler_characterization.rs
@@ -1,0 +1,265 @@
+mod support;
+
+use rive_cli::authoring::{LoweredAuthoring, SourceMapEntry, lower_authoring_json};
+use serde_json::{Value, json};
+use support::assert_builds;
+
+fn literal(value: f64, unit: &str) -> Value {
+    json!({ "kind": "literal", "value": value, "unit": unit })
+}
+
+fn mixed_document() -> Value {
+    json!({
+        "authoring_format_version": 0,
+        "artboard": {
+            "id": "compiler-stage",
+            "width": { "value": 320.0, "unit": "px" },
+            "height": { "value": 200.0, "unit": "px" }
+        },
+        "visual": {
+            "nodes": [
+                {
+                    "kind": "rectangle",
+                    "id": "card",
+                    "width": literal(80.0, "px"),
+                    "height": literal(48.0, "px"),
+                    "fill": "#172554"
+                }
+            ]
+        },
+        "motion": {
+            "poses": [
+                {
+                    "id": "rest",
+                    "targets": [
+                        {
+                            "target": "card",
+                            "transform": { "x": literal(16.0, "px") }
+                        }
+                    ]
+                },
+                {
+                    "id": "moved",
+                    "targets": [
+                        {
+                            "target": "card",
+                            "transform": { "x": literal(160.0, "px") }
+                        }
+                    ]
+                }
+            ],
+            "tracks": [
+                {
+                    "id": "entrance",
+                    "fps": 60,
+                    "duration_frames": literal(30.0, "scalar"),
+                    "keyframes": [
+                        { "frame": literal(0.0, "scalar"), "pose": "rest" },
+                        { "frame": literal(30.0, "scalar"), "pose": "moved" }
+                    ]
+                },
+                {
+                    "id": "settle",
+                    "fps": 60,
+                    "duration_frames": literal(30.0, "scalar"),
+                    "keyframes": [
+                        { "frame": literal(0.0, "scalar"), "pose": "moved" },
+                        { "frame": literal(30.0, "scalar"), "pose": "rest" }
+                    ]
+                }
+            ],
+            "raw_animations": [
+                {
+                    "id": "raw-first",
+                    "value": {
+                        "name": "raw_first",
+                        "fps": 60,
+                        "duration": 1,
+                        "keyframes": []
+                    }
+                },
+                {
+                    "id": "raw-second",
+                    "value": {
+                        "name": "raw_second",
+                        "fps": 60,
+                        "duration": 1,
+                        "keyframes": []
+                    }
+                }
+            ]
+        },
+        "behavior": {
+            "raw_state_machines": [
+                {
+                    "id": "mixed-machine",
+                    "value": {
+                        "name": "mixed_machine",
+                        "layers": [
+                            {
+                                "states": [
+                                    { "type": "entry" },
+                                    { "type": "exit" },
+                                    {
+                                        "type": "animation",
+                                        "animation": "auth__compiler_2dstage__settle__animation"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    })
+}
+
+fn lower(input: &Value) -> LoweredAuthoring {
+    lower_authoring_json(&input.to_string()).expect("mixed authoring document must lower")
+}
+
+fn source_entry<'a>(lowered: &'a LoweredAuthoring, authored_id: &str) -> &'a SourceMapEntry {
+    lowered
+        .source_map
+        .entries
+        .iter()
+        .find(|entry| entry.authored_id == authored_id)
+        .expect("expected source-map entry")
+}
+
+fn assert_source_entry(
+    lowered: &LoweredAuthoring,
+    authored_id: &str,
+    authored_path: &str,
+    runtime_names: &[&str],
+    scene_paths: &[&str],
+) {
+    let entry = source_entry(lowered, authored_id);
+    assert_eq!(entry.authored_path, authored_path);
+    assert_eq!(entry.definition_path, None);
+    assert_eq!(
+        entry.runtime_names,
+        runtime_names
+            .iter()
+            .map(|name| (*name).to_string())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        entry.scene_paths,
+        scene_paths
+            .iter()
+            .map(|path| (*path).to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn mixed_typed_raw_motion_preserves_order_references_and_source_identity() {
+    let input = mixed_document();
+    let first = lower(&input);
+    let second = lower(&input);
+
+    assert_eq!(first.scene, second.scene);
+    assert_eq!(first.source_map, second.source_map);
+
+    let animation_names = first.scene["artboard"]["animations"]
+        .as_array()
+        .expect("mixed animation list")
+        .iter()
+        .map(|animation| animation["name"].as_str().expect("animation name"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        animation_names,
+        vec![
+            "auth__compiler_2dstage__entrance__animation",
+            "auth__compiler_2dstage__settle__animation",
+            "raw_first",
+            "raw_second"
+        ]
+    );
+
+    assert_eq!(
+        first.scene["artboard"]["state_machines"][0]["layers"][0]["states"][2]["animation"],
+        "auth__compiler_2dstage__settle__animation"
+    );
+
+    let compiler_entries = first
+        .source_map
+        .entries
+        .iter()
+        .filter(|entry| {
+            entry.authored_path.starts_with("$.motion.")
+                || entry.authored_path.starts_with("$.behavior.")
+        })
+        .map(|entry| entry.authored_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        compiler_entries,
+        vec![
+            "entrance",
+            "settle",
+            "raw-first",
+            "raw-second",
+            "mixed-machine"
+        ]
+    );
+
+    assert_source_entry(
+        &first,
+        "entrance",
+        "$.motion.tracks[0]",
+        &["auth__compiler_2dstage__entrance__animation"],
+        &["/artboard/animations/0"],
+    );
+    assert_source_entry(
+        &first,
+        "settle",
+        "$.motion.tracks[1]",
+        &["auth__compiler_2dstage__settle__animation"],
+        &["/artboard/animations/1"],
+    );
+    assert_source_entry(
+        &first,
+        "raw-first",
+        "$.motion.raw_animations[0]",
+        &["raw_first"],
+        &["/artboard/animations/2"],
+    );
+    assert_source_entry(
+        &first,
+        "raw-second",
+        "$.motion.raw_animations[1]",
+        &["raw_second"],
+        &["/artboard/animations/3"],
+    );
+    assert_source_entry(
+        &first,
+        "mixed-machine",
+        "$.behavior.raw_state_machines[0]",
+        &["mixed_machine"],
+        &["/artboard/state_machines/0"],
+    );
+
+    assert_builds(first.scene);
+}
+
+#[test]
+fn raw_animation_diagnostic_keeps_authored_index_after_typed_prefix() {
+    let mut input = mixed_document();
+    input["motion"]["raw_animations"][0]["value"] = json!(7);
+
+    let error = lower_authoring_json(&input.to_string())
+        .expect_err("invalid raw animation must fail after typed tracks are generated");
+    assert_eq!(error.diagnostics.len(), 1);
+    let diagnostic = &error.diagnostics[0];
+    assert_eq!(diagnostic.code, "invalid_raw_scene_fragment");
+    assert_eq!(
+        diagnostic.path,
+        "$.motion.raw_animations[0].value",
+        "the generated two-track prefix must not leak into authored diagnostics"
+    );
+    assert_eq!(
+        diagnostic.message,
+        "raw SceneSpec escape must be a JSON object"
+    );
+}

--- a/tests/authoring_compiler_characterization.rs
+++ b/tests/authoring_compiler_characterization.rs
@@ -254,8 +254,7 @@ fn raw_animation_diagnostic_keeps_authored_index_after_typed_prefix() {
     let diagnostic = &error.diagnostics[0];
     assert_eq!(diagnostic.code, "invalid_raw_scene_fragment");
     assert_eq!(
-        diagnostic.path,
-        "$.motion.raw_animations[0].value",
+        diagnostic.path, "$.motion.raw_animations[0].value",
         "the generated two-track prefix must not leak into authored diagnostics"
     );
     assert_eq!(


### PR DESCRIPTION
## Scope

Complete the first characterization slice in the existing one-pass Authoring compiler architecture gate before changing production code.

The current frontend lowers visuals once to discover motion targets, converts typed tracks into raw fragments, clones and clears the AuthoringSpec, lowers the full scene a second time, then repairs generated/raw source paths and diagnostics by string offset. Existing tests covered the individual capabilities, but not the complete mixed boundary that the refactor must preserve.

## Characterization contracts

- two typed tracks remain in authored order before two raw animation escapes;
- a raw state machine can reference the second generated typed-track runtime name in the same document;
- repeated lowering produces identical scene and source map values;
- typed tracks, raw animations, and raw behavior retain exact authored IDs, paths, runtime names, scene paths, and source-map ordering;
- a raw-animation diagnostic emitted after the generated two-track prefix maps back to the original authored raw index rather than leaking the internal offset;
- the mixed result still passes the canonical builder;
- the existing P2 Cairn todo records the migration boundary and marks architecture-gate step 1 complete.

## Roadmap reconciliation

This is step 1 of the architecture gate already recorded in `meta/todos/todo.motion-authoring-compiler.md`. It adds no feature, schema, roadmap item, or production-code change. These contracts are the migration boundary for the subsequent internal `AuthoringCompiler` state and one-pass lowering work.

## Verification

- initial head `eff8fbb`: Rust 1.88 run `31187208884` passed; CI run `31187208893` passed browser contracts but stopped only at rustfmt before Clippy/tests;
- formatted characterization head `f035f70`: Rust 1.88 run `31187442874` passed; complete CI run `31187441981` passed;
- final exact head `4b1de3c`: Rust 1.88 run `31187947546` passed; complete CI run `31187947325` passed;
- complete CI includes rustfmt, Clippy, all Rust tests, browser contracts, Cairn architecture validation, official-runtime evidence, demo, site, Playwright, and visual regression.